### PR TITLE
feat: GH Actions for pr testing

### DIFF
--- a/.github/actions/node-and-build/action.yml
+++ b/.github/actions/node-and-build/action.yml
@@ -1,0 +1,38 @@
+name: Set Node and Build
+description: Checks out Amplify and builds the package
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Node.js 16
+      uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0 https://github.com/actions/setup-node/commit/64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
+      with:
+        node-version: 16
+      env:
+        SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
+    - name: Install
+      run: |
+        mv .yarnrc ._yarnrc
+        yarn
+      shell: bash
+    - name: Bootstrap
+      run: yarn bootstrap
+      shell: bash
+    - uses: actions/cache@v2
+      id: cache-build-artifacts
+      with:
+        path: |
+          **/dist
+          **/lib
+          **/
+          **/lib-esm/
+          **/es/
+          **/esm/
+          **/cjs/
+        key: ${{ runner.os }}-build-artifacts-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-build-artifacts-
+    - name: Build packages
+      if: steps.cache-build-artifacts.outputs.cache-hit != 'true'
+      run: yarn build
+      shell: bash

--- a/.github/workflows/callable-bundle-size-tests.yml
+++ b/.github/workflows/callable-bundle-size-tests.yml
@@ -1,0 +1,19 @@
+name: 'Unit Tests'
+
+on:
+  workflow_call:
+
+jobs:
+  bundle_size_tests:
+    name: Bundle Size Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
+        with:
+          # Minimal depth 2 so we can checkout the commit before possible merge commit.
+          fetch-depth: 2
+      - name: Setup node and build the repository
+        uses: ./.github/actions/node-and-build
+      - name: Run Bundle Size Tests
+        run: yarn test:size

--- a/.github/workflows/callable-codeql.yml
+++ b/.github/workflows/callable-codeql.yml
@@ -2,8 +2,7 @@
 name: 'CodeQL'
 
 on:
-  push:
-  pull_request:
+  workflow_call:
 
 jobs:
   analyze:

--- a/.github/workflows/callable-get-package-list.yml
+++ b/.github/workflows/callable-get-package-list.yml
@@ -1,0 +1,41 @@
+name: 'Capture Package Names List to Outputs'
+
+on:
+  workflow_call:
+    outputs:
+      packages:
+        description: 'The json encoded package list'
+        value: ${{ jobs.get-package-list.outputs.packages }}
+jobs:
+  get-package-list:
+    # Prepares the 'bazelversion' axis of the test matrix
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
+        with:
+          # Minimal depth 2 so we can checkout the commit before possible merge commit.
+          fetch-depth: 2
+      - uses: actions/cache@v2
+        id: cache-package-list
+        with:
+          path: |
+            **/package-list.json
+          key: ${{ runner.os }}-package-list-${{ hashFiles('**/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-package-list-
+      - name: Install
+        if: steps.cache-package-list.outputs.cache-hit != 'true'
+        run: yarn
+        shell: bash
+      # Need the repo checked out in order to read the file
+      - name: Dump Package List
+        if: steps.cache-package-list.outputs.cache-hit != 'true'
+        run: |
+          echo "packages=$(yarn lerna ls | egrep -v "lerna|Done|yarn" | jq -R -s -c 'split("\n")[:-1]')" > package-list.json
+      - name: Get Package List
+        id: get_package_list
+        run: |
+          cat package-list.json >> $GITHUB_OUTPUT
+    outputs:
+      packages: ${{ steps.get_package_list.outputs.packages }}

--- a/.github/workflows/callable-unit-tests.yml
+++ b/.github/workflows/callable-unit-tests.yml
@@ -1,0 +1,23 @@
+name: 'Unit Tests'
+
+on:
+  workflow_call:
+    inputs:
+      package:
+        required: true
+        type: string
+
+jobs:
+  unit_test:
+    name: Unit Tests - ${{ inputs.package }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
+        with:
+          # Minimal depth 2 so we can checkout the commit before possible merge commit.
+          fetch-depth: 2
+      - name: Setup node and build the repository
+        uses: ./.github/actions/node-and-build
+      - name: Run tests
+        run: npx lerna exec --scope ${{ inputs.package }} yarn test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,34 @@
+name: PR Validation
+
+on:
+  pull_request:
+
+jobs:
+  prebuild:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
+        with:
+          # Minimal depth 2 so we can checkout the commit before possible merge commit.
+          fetch-depth: 2
+      - name: Setup node and build the repository
+        uses: ./.github/actions/node-and-build
+  get-package-list:
+    uses: ./.github/workflows/callable-get-package-list.yml
+  codeql:
+    uses: ./.github/workflows/callable-codeql.yml
+  unit-tests:
+    needs:
+      - prebuild
+      - get-package-list
+    strategy:
+      matrix:
+        package: ${{ fromJSON(needs.get-package-list.outputs.packages) }}
+      fail-fast: true
+    uses: ./.github/workflows/callable-unit-tests.yml
+    with:
+      package: ${{ matrix.package }}
+  bundle-size-tests:
+    needs: prebuild
+    uses: ./.github/workflows/callable-bundle-size-tests.yml


### PR DESCRIPTION
#### Description of changes
Using the PR process modeling to settle patterns for GH Workflow/Action factoring.
- Pre-build and cache the package artifacts.
- Discover the package name list
- Run the bundle size checks against all packages
- Run the unit tests per category (using the discovered names to parallelize)
- Make CodeQL a callable and include it in the PR checks

Caching and per-category test separation introduced because original runs without caching where ~22. With these changes, runtime is ~11 minutes. There is a remaining 2-7 minutes that would normally be cached out using a checked in `yarn.lock` file. Investigating this as a further refinement.

#### Description of how you validated changes
Posting cross fork PRs and verifying that the workflows are operating as expected.

https://github.com/stocaaro/amplify-js/actions/runs/5347421341


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
