### PR TITLE
Feat/GitHub actions/ashwin 04 e2e

### DIFF
--- a/.github/workflows/callable-e2e-runner.yml
+++ b/.github/workflows/callable-e2e-runner.yml
@@ -39,10 +39,15 @@ jobs:
       amplifyjs_dir: ${{ matrix.integ-config.amplifyjs_dir || false }}
       browser: |
         ${{
+          fromJson(
+            needs.e2e-prep.outputs.integ-utils
+          )[matrix.integ-config.browser]
+          &&
           toJSON(
             fromJson(
               needs.e2e-prep.outputs.integ-utils
             )[matrix.integ-config.browser]
           )
-          || matrix.integ-config.browser
+          ||
+          format('[{0}]', toJSON(matrix.integ-config.browser))
         }}


### PR DESCRIPTION
#### Description of changes
When a single browser is provided in integ config 
example 
```
-   test_name: 'Vue Custom Authenticator'
    framework: vue
    category: auth
    sample_name: amplify-authenticator
    spec: custom-authenticator
    browser: firefox # =====> single browser
```

The integ runner does not pass on the mentioned browser instead pass on null. And integ-test callable just defaults to chrome

handle two cases
1. browser group is passed
```
-   test_name: 'Vue Custom Authenticator'
    framework: vue
    category: auth
    sample_name: amplify-authenticator
    spec: custom-authenticator
    browser: minimal_browser_list # =====> browser group from utils
```

2. single browser is passed
```
-   test_name: 'Vue Custom Authenticator'
    framework: vue
    category: auth
    sample_name: amplify-authenticator
    spec: custom-authenticator
    browser: firefox # =====> single browser
```


Not currently supported
```
-   test_name: 'Vue Custom Authenticator'
    framework: vue
    category: auth
    sample_name: amplify-authenticator
    spec: custom-authenticator
    browser:  # =====> NOT SUPPORTED
      - firefox
      - chrome
```
An input like this would fail the pipeline

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
