### PR TITLE
chore: add e2e integ_datastore_auth tests

### DIFF
--- a/.github/integ-config/integ-api.yml
+++ b/.github/integ-config/integ-api.yml
@@ -1,7 +1,7 @@
-# React
-- test_name: 'React GraphQL API'
-  framework: react
-  category: api
-  sample_name: graphql
-  spec: graphql
-  browser: minimal_browser_list
+# # React
+# - test_name: 'React GraphQL API'
+#   framework: react
+#   category: api
+#   sample_name: graphql
+#   spec: graphql
+#   browser: minimal_browser_list

--- a/.github/integ-config/integ-auth.yml
+++ b/.github/integ-config/integ-auth.yml
@@ -1,113 +1,113 @@
-# React
-# integ_react_auth_1
-- test_name: 'React Authenticator'
-  framework: react
-  category: auth
-  sample_name: amplify-authenticator
-  spec: new-ui-authenticator
-  browser: minimal_browser_list
-- test_name: 'Guest to Authenticated User"'
-  framework: react
-  category: auth
-  sample_name: guest-to-auth-user
-  spec: guest-to-auth-user
-  browser: minimal_browser_list
-- test_name: 'React Typescript Authenticator'
-  framework: react
-  category: auth
-  sample_name: typescript-amplify-authenticator
-  spec: new-ui-authenticator
-  browser: minimal_browser_list
+# # React
+# # integ_react_auth_1
+# - test_name: 'React Authenticator'
+#   framework: react
+#   category: auth
+#   sample_name: amplify-authenticator
+#   spec: new-ui-authenticator
+#   browser: minimal_browser_list
+# - test_name: 'Guest to Authenticated User"'
+#   framework: react
+#   category: auth
+#   sample_name: guest-to-auth-user
+#   spec: guest-to-auth-user
+#   browser: minimal_browser_list
+# - test_name: 'React Typescript Authenticator'
+#   framework: react
+#   category: auth
+#   sample_name: typescript-amplify-authenticator
+#   spec: new-ui-authenticator
+#   browser: minimal_browser_list
 
-# integ_react_auth_2
--   test_name: 'React Credentials Different Region'
-    framework: react
-    category: auth
-    sample_name: credentials-auth
-    spec: credentials-auth
-    browser: minimal_browser_list
--   test_name: 'React Custom Authenticator'
-    framework: react
-    category: auth
-    sample_name: amplify-authenticator
-    spec: new-ui-custom-authenticator
-    browser: minimal_browser_list
--   test_name: 'React Custom Authenticator'
-    framework: react
-    category: auth
-    sample_name: with-authenticator
-    spec: new-ui-authenticator
-    browser: minimal_browser_list
--   test_name: 'Sign In after Sign Up'
-    framework: react
-    category: auth
-    sample_name: auto-signin-after-signup
-    spec: auto-signin-after-signup
-    browser: minimal_browser_list
+# # integ_react_auth_2
+# -   test_name: 'React Credentials Different Region'
+#     framework: react
+#     category: auth
+#     sample_name: credentials-auth
+#     spec: credentials-auth
+#     browser: minimal_browser_list
+# -   test_name: 'React Custom Authenticator'
+#     framework: react
+#     category: auth
+#     sample_name: amplify-authenticator
+#     spec: new-ui-custom-authenticator
+#     browser: minimal_browser_list
+# -   test_name: 'React Custom Authenticator'
+#     framework: react
+#     category: auth
+#     sample_name: with-authenticator
+#     spec: new-ui-authenticator
+#     browser: minimal_browser_list
+# -   test_name: 'Sign In after Sign Up'
+#     framework: react
+#     category: auth
+#     sample_name: auto-signin-after-signup
+#     spec: auto-signin-after-signup
+#     browser: minimal_browser_list
 
-# Angular
-# integ_angular_auth
--   test_name: 'Angular Authenticator'
-    framework: angular
-    category: auth
-    sample_name: amplify-authenticator
-    spec: ui-amplify-authenticator
-    browser: minimal_browser_list
--   test_name: 'Angular Custom Authenticator'
-    framework: angular
-    category: auth
-    sample_name: amplify-authenticator
-    spec: custom-authenticator
-    browser: minimal_browser_list
+# # Angular
+# # integ_angular_auth
+# -   test_name: 'Angular Authenticator'
+#     framework: angular
+#     category: auth
+#     sample_name: amplify-authenticator
+#     spec: ui-amplify-authenticator
+#     browser: minimal_browser_list
+# -   test_name: 'Angular Custom Authenticator'
+#     framework: angular
+#     category: auth
+#     sample_name: amplify-authenticator
+#     spec: custom-authenticator
+#     browser: minimal_browser_list
 
-# Javascript
-# integ_javascript_auth
--   test_name: 'JavaScript Auth CDN'
-    framework: javascript
-    category: auth
-    sample_name: auth-cdn
-    spec: auth-cdn
-    browser: minimal_browser_list
-    amplifyjs_dir: true
+# # Javascript
+# # integ_javascript_auth
+# -   test_name: 'JavaScript Auth CDN'
+#     framework: javascript
+#     category: auth
+#     sample_name: auth-cdn
+#     spec: auth-cdn
+#     browser: minimal_browser_list
+#     amplifyjs_dir: true
 
-# Vue
-# integ_vue_auth
--   test_name: 'Legacy Vue Authenticator'
-    framework: vue
-    category: auth
-    sample_name: amplify-authenticator-legacy
-    spec: authenticator
-    browser: minimal_browser_list
--   test_name: 'Vue 3 Authenticator'
-    framework: vue
-    category: auth
-    sample_name: authenticator-vue3
-    spec: new-ui-authenticator
-    browser: minimal_browser_list
--   test_name: 'Vue Custom Authenticator'
-    framework: vue
-    category: auth
-    sample_name: amplify-authenticator
-    spec: custom-authenticator
-    browser: minimal_browser_list
+# # Vue
+# # integ_vue_auth
+# -   test_name: 'Legacy Vue Authenticator'
+#     framework: vue
+#     category: auth
+#     sample_name: amplify-authenticator-legacy
+#     spec: authenticator
+#     browser: minimal_browser_list
+# -   test_name: 'Vue 3 Authenticator'
+#     framework: vue
+#     category: auth
+#     sample_name: authenticator-vue3
+#     spec: new-ui-authenticator
+#     browser: minimal_browser_list
+# -   test_name: 'Vue Custom Authenticator'
+#     framework: vue
+#     category: auth
+#     sample_name: amplify-authenticator
+#     spec: custom-authenticator
+#     browser: minimal_browser_list
 
-# Next
-# integ_next_auth
--   test_name: 'Authenticator and SSR page'
-    framework: next
-    category: auth
-    sample_name: auth-ssr
-    spec: auth-ssr
-    browser: minimal_browser_list
--   test_name: 'Authenticator and RSC page'
-    framework: next
-    category: auth
-    sample_name: auth-rsc
-    spec: auth-rsc
-    browser: minimal_browser_list
--   test_name: 'NextJS Auth Custom Implementation with SSR'
-    framework: next
-    category: auth
-    sample_name: custom-auth-ssr
-    spec: authenticator
-    browser: minimal_browser_list
+# # Next
+# # integ_next_auth
+# -   test_name: 'Authenticator and SSR page'
+#     framework: next
+#     category: auth
+#     sample_name: auth-ssr
+#     spec: auth-ssr
+#     browser: minimal_browser_list
+# -   test_name: 'Authenticator and RSC page'
+#     framework: next
+#     category: auth
+#     sample_name: auth-rsc
+#     spec: auth-rsc
+#     browser: minimal_browser_list
+# -   test_name: 'NextJS Auth Custom Implementation with SSR'
+#     framework: next
+#     category: auth
+#     sample_name: custom-auth-ssr
+#     spec: authenticator
+#     browser: minimal_browser_list

--- a/.github/integ-config/integ-datastore.yml
+++ b/.github/integ-config/integ-datastore.yml
@@ -1,120 +1,134 @@
-# React
-# integ_react_datastore
-- test_name: 'React DataStore'
-  framework: react
-  category: datastore
-  sample_name: many-to-many
-  spec: many-to-many
-  browser: minimal_browser_list
-
-# integ_react_datastore_v2
-- test_name: 'React DataStore CLI v2'
-  framework: react
-  category: datastore
-  sample_name: v2/many-to-many-v2
-  spec: many-to-many
-  browser: minimal_browser_list
-
-# integ_react_datastore_multi_auth_one_rule
-- test_name: 'React DataStore Multi-Auth - One Rule'
-  framework: react
-  category: datastore
-  sample_name: multi-auth
-  spec: multi-auth-one-rule
-  browser: minimal_browser_list
-
-# integ_react_datastore_multi_auth_one_rule_v2
-- test_name: 'React DataStore Multi-Auth - One Rule CLI v2'
-  framework: react
-  category: datastore
-  sample_name: v2/multi-auth-v2
-  spec: multi-auth-one-rule
-  browser: minimal_browser_list
-
-# integ_react_datastore_multi_auth_two_rules
-- test_name: 'React DataStore Multi-Auth - Two Rules'
-  framework: react
-  category: datastore
-  sample_name: multi-auth
-  spec: multi-auth-two-rules
-  browser: minimal_browser_list
-
-# integ_react_datastore_multi_auth_two_rules_v2
-- test_name: 'React DataStore Multi-Auth - Two Rules CLI v2'
-  framework: react
-  category: datastore
-  sample_name: v2/multi-auth-v2
-  spec: multi-auth-two-rules
-  browser: minimal_browser_list
-
-# integ_react_datastore_multi_auth_three_plus_rules
-- test_name: 'React DataStore Multi-Auth - Three Plus Rules'
-  framework: react
-  category: datastore
-  sample_name: multi-auth
-  spec: multi-auth-three-plus-rules
-  browser: minimal_browser_list
-
-# integ_react_datastore_multi_auth_three_plus_rules_v2
-- test_name: 'React DataStore Multi-Auth - Three Plus Rules CLI v2'
-  framework: react
-  category: datastore
-  sample_name: v2/multi-auth-v2
-  spec: multi-auth-three-plus-rules
-  browser: minimal_browser_list
-
-# integ_react_datastore_subs_disabled
-- test_name: 'DataStore - Subs Disabled'
-  framework: react
-  category: datastore
-  sample_name: subs-disabled
-  spec: subs-disabled
-  browser: minimal_browser_list
-
-# integ_react_datastore_subs_disabled_v2
-- test_name: 'DataStore - Subs Disabled CLI v2'
-  framework: react
-  category: datastore
-  sample_name: v2/subs-disabled-v2
-  spec: subs-disabled
-  browser: minimal_browser_list
-
-# integ_react_datastore_consecutive_saves
-- test_name: 'DataStore - Subs Disabled'
-  framework: react
-  category: datastore
-  sample_name: consecutive-saves
-  spec: consecutive-saves
-  browser: minimal_browser_list
-
-# integ_react_datastore_consecutive_saves_v2
-- test_name: 'DataStore - Subs Disabled CLI v2'
-  framework: react
-  category: datastore
-  sample_name: v2/consecutive-saves-v2
-  spec: consecutive-saves
-  browser: minimal_browser_list
-
-# # integ_react_datastore_observe_query
-# - test_name: 'DataStore - Observe Query'
+# # React
+# # integ_react_datastore
+# - test_name: 'React DataStore'
 #   framework: react
 #   category: datastore
-#   sample_name: observe-query
-#   spec: observe-query
+#   sample_name: many-to-many
+#   spec: many-to-many
 #   browser: minimal_browser_list
 
-# # integ_react_datastore_observe_query_v2
-# - test_name: 'DataStore - Observe Query CLI v2'
+# # integ_react_datastore_v2
+# - test_name: 'React DataStore CLI v2'
 #   framework: react
 #   category: datastore
-#   sample_name: v2/observe-query-v2
-#   spec: observe-query
+#   sample_name: v2/many-to-many-v2
+#   spec: many-to-many
 #   browser: minimal_browser_list
 
-# integ_react_datastore_schema_drift
-- test_name: 'DataStore - Schema Drift'
-  framework: react
-  category: datastore
-  sample_name: schema-drift
-  spec: schema-drift
-  browser: minimal_browser_list
+# # integ_react_datastore_multi_auth_one_rule
+# - test_name: 'React DataStore Multi-Auth - One Rule'
+#   framework: react
+#   category: datastore
+#   sample_name: multi-auth
+#   spec: multi-auth-one-rule
+#   browser: minimal_browser_list
+
+# # integ_react_datastore_multi_auth_one_rule_v2
+# - test_name: 'React DataStore Multi-Auth - One Rule CLI v2'
+#   framework: react
+#   category: datastore
+#   sample_name: v2/multi-auth-v2
+#   spec: multi-auth-one-rule
+#   browser: minimal_browser_list
+
+# # integ_react_datastore_multi_auth_two_rules
+# - test_name: 'React DataStore Multi-Auth - Two Rules'
+#   framework: react
+#   category: datastore
+#   sample_name: multi-auth
+#   spec: multi-auth-two-rules
+#   browser: minimal_browser_list
+
+# # integ_react_datastore_multi_auth_two_rules_v2
+# - test_name: 'React DataStore Multi-Auth - Two Rules CLI v2'
+#   framework: react
+#   category: datastore
+#   sample_name: v2/multi-auth-v2
+#   spec: multi-auth-two-rules
+#   browser: minimal_browser_list
+
+# # integ_react_datastore_multi_auth_three_plus_rules
+# - test_name: 'React DataStore Multi-Auth - Three Plus Rules'
+#   framework: react
+#   category: datastore
+#   sample_name: multi-auth
+#   spec: multi-auth-three-plus-rules
+#   browser: minimal_browser_list
+
+# # integ_react_datastore_multi_auth_three_plus_rules_v2
+# - test_name: 'React DataStore Multi-Auth - Three Plus Rules CLI v2'
+#   framework: react
+#   category: datastore
+#   sample_name: v2/multi-auth-v2
+#   spec: multi-auth-three-plus-rules
+#   browser: minimal_browser_list
+
+# # integ_react_datastore_subs_disabled
+# - test_name: 'DataStore - Subs Disabled'
+#   framework: react
+#   category: datastore
+#   sample_name: subs-disabled
+#   spec: subs-disabled
+#   browser: minimal_browser_list
+
+# # integ_react_datastore_subs_disabled_v2
+# - test_name: 'DataStore - Subs Disabled CLI v2'
+#   framework: react
+#   category: datastore
+#   sample_name: v2/subs-disabled-v2
+#   spec: subs-disabled
+#   browser: minimal_browser_list
+
+# # integ_react_datastore_consecutive_saves
+# - test_name: 'DataStore - Subs Disabled'
+#   framework: react
+#   category: datastore
+#   sample_name: consecutive-saves
+#   spec: consecutive-saves
+#   browser: minimal_browser_list
+
+# # integ_react_datastore_consecutive_saves_v2
+# - test_name: 'DataStore - Subs Disabled CLI v2'
+#   framework: react
+#   category: datastore
+#   sample_name: v2/consecutive-saves-v2
+#   spec: consecutive-saves
+#   browser: minimal_browser_list
+
+# # # integ_react_datastore_observe_query
+# # - test_name: 'DataStore - Observe Query'
+# #   framework: react
+# #   category: datastore
+# #   sample_name: observe-query
+# #   spec: observe-query
+# #   browser: minimal_browser_list
+
+# # # integ_react_datastore_observe_query_v2
+# # - test_name: 'DataStore - Observe Query CLI v2'
+# #   framework: react
+# #   category: datastore
+# #   sample_name: v2/observe-query-v2
+# #   spec: observe-query
+# #   browser: minimal_browser_list
+
+# # integ_react_datastore_schema_drift
+# - test_name: 'DataStore - Schema Drift'
+#   framework: react
+#   category: datastore
+#   sample_name: schema-drift
+#   spec: schema-drift
+#   browser: minimal_browser_list
+
+# integ_datastore_auth
+-   test_name: 'DataStore Auth - Chrome'
+    framework: react
+    category: datastore
+    sample_name: datastore_auth_scenarios_sample_spec
+    spec: ''
+    browser: chrome    
+-   test_name: 'DataStore Auth - Firefox'
+    framework: react
+    category: datastore
+    sample_name: datastore_auth_scenarios_sample_spec
+    spec: ''
+    browser: firefox

--- a/.github/integ-config/integ-datastore.yml
+++ b/.github/integ-config/integ-datastore.yml
@@ -132,3 +132,17 @@
     sample_name: datastore_auth_scenarios_sample_spec
     spec: ''
     browser: firefox
+
+# # integ_datastore_auth_v2
+# -   test_name: 'DataStore Auth CLI v2 - Chrome'
+#     framework: react
+#     category: datastore
+#     sample_name: v2/<< parameters.scenario >>-v2
+#     spec: << parameters.scenario >>
+#     browser: chrome
+# -   test_name: 'DataStore Auth CLI v2 - Firefox'
+#     framework: react
+#     category: datastore
+#     sample_name: v2/<< parameters.scenario >>-v2
+#     spec: << parameters.scenario >>
+#     browser: firefox

--- a/.github/integ-config/integ-interactions.yml
+++ b/.github/integ-config/integ-interactions.yml
@@ -1,45 +1,45 @@
-# React
-# integ_react_interactions
--   test_name: 'React Interactions'
-    framework: react
-    category: interactions
-    sample_name: chatbot-component
-    spec: chatbot-component
-    browser: minimal_browser_list
--   test_name: 'Chatbot V1'
-    framework: react
-    category: interactions
-    sample_name: lex-test-component
-    spec: chatbot-v1
-    browser: minimal_browser_list
--   test_name: 'Chatbot V2'
-    framework: react
-    category: interactions
-    sample_name: lex-test-component
-    spec: chatbot-v2
-    browser: minimal_browser_list
+# # React
+# # integ_react_interactions
+# -   test_name: 'React Interactions'
+#     framework: react
+#     category: interactions
+#     sample_name: chatbot-component
+#     spec: chatbot-component
+#     browser: minimal_browser_list
+# -   test_name: 'Chatbot V1'
+#     framework: react
+#     category: interactions
+#     sample_name: lex-test-component
+#     spec: chatbot-v1
+#     browser: minimal_browser_list
+# -   test_name: 'Chatbot V2'
+#     framework: react
+#     category: interactions
+#     sample_name: lex-test-component
+#     spec: chatbot-v2
+#     browser: minimal_browser_list
 
-# Angular
-# integ_angular_interactions
--   test_name: 'Angular Interactions'
-    framework: angular
-    category: interactions
-    sample_name: chatbot-component
-    spec: chatbot-component
-    browser: minimal_browser_list
+# # Angular
+# # integ_angular_interactions
+# -   test_name: 'Angular Interactions'
+#     framework: angular
+#     category: interactions
+#     sample_name: chatbot-component
+#     spec: chatbot-component
+#     browser: minimal_browser_list
 
-# Vue
-# integ_vue_interactions
--   test_name: 'Vue 2 Interactions'
-    framework: vue
-    category: interactions
-    sample_name: chatbot-component
-    spec: chatbot-component
-    browser: chrome
--   test_name: 'Vue 3 Interactions'
-    framework: vue
-    category: interactions
-    sample_name: chatbot-component-vue3
-    spec: chatbot-component
-    browser: chrome
+# # Vue
+# # integ_vue_interactions
+# -   test_name: 'Vue 2 Interactions'
+#     framework: vue
+#     category: interactions
+#     sample_name: chatbot-component
+#     spec: chatbot-component
+#     browser: chrome
+# -   test_name: 'Vue 3 Interactions'
+#     framework: vue
+#     category: interactions
+#     sample_name: chatbot-component-vue3
+#     spec: chatbot-component
+#     browser: chrome
 

--- a/.github/integ-config/integ-predictions.yml
+++ b/.github/integ-config/integ-predictions.yml
@@ -1,8 +1,8 @@
-# React
-# integ_react_predictions
-- test_name: 'React Predictions'
-  framework: react
-  category: predictions
-  sample_name: multi-user-translation
-  spec: multiuser-translation
-  browser: minimal_browser_list
+# # React
+# # integ_react_predictions
+# - test_name: 'React Predictions'
+#   framework: react
+#   category: predictions
+#   sample_name: multi-user-translation
+#   spec: multiuser-translation
+#   browser: minimal_browser_list

--- a/.github/integ-config/integ-storage.yml
+++ b/.github/integ-config/integ-storage.yml
@@ -1,24 +1,24 @@
-# React
-# integ_react_storage
-- test_name: 'React Storage'
-  framework: react
-  category: storage
-  sample_name: storageApp
-  spec: storage
-  browser: minimal_browser_list
+# # React
+# # integ_react_storage
+# - test_name: 'React Storage'
+#   framework: react
+#   category: storage
+#   sample_name: storageApp
+#   spec: storage
+#   browser: minimal_browser_list
 
-# integ_react_storage_multipart_progress
-- test_name: 'React Storage Multi-Part Upload with Progress'
-  framework: react
-  category: storage
-  sample_name: multi-part-upload-with-progress
-  spec: multi-part-upload-with-progress
-  browser: minimal_browser_list
+# # integ_react_storage_multipart_progress
+# - test_name: 'React Storage Multi-Part Upload with Progress'
+#   framework: react
+#   category: storage
+#   sample_name: multi-part-upload-with-progress
+#   spec: multi-part-upload-with-progress
+#   browser: minimal_browser_list
 
-# integ_react_storage_copy
-- test_name: 'React Storage Copy'
-  framework: react
-  category: storage
-  sample_name: multi-part-copy-with-progress
-  spec: multi-part-copy-with-progress
-  browser: minimal_browser_list
+# # integ_react_storage_copy
+# - test_name: 'React Storage Copy'
+#   framework: react
+#   category: storage
+#   sample_name: multi-part-copy-with-progress
+#   spec: multi-part-copy-with-progress
+#   browser: minimal_browser_list

--- a/.github/integ-config/utils.yml
+++ b/.github/integ-config/utils.yml
@@ -8,18 +8,17 @@ extended_browser_list:
   - edge
 
 datastore_auth_scenarios_sample_spec:
-  # - owner-based-default owner-based-default # TODO: Add `owner-based-operations` when tests pass
-  # - static-user-pool-groups-default static-user-pool-groups-default
-  # - static-user-pool-groups-operations static-user-pool-groups-operations
-  # - owner-and-group-different-models-default owner-and-group-different-models-default
-  # - owner-and-group-same-model-default owner-and-group-same-model-default
-  # - owner-and-group-same-model-operations owner-and-group-same-model-operations
-  # - dynamic-user-pool-groups-default dynamic-user-pool-groups-default
-  # - dynamic-user-pool-groups-owner-based-default dynamic-user-pool-groups-owner-based-default
-  # - private-auth-default private-auth-default
-  # - private-auth-iam private-auth-iam
-  # - public-auth-default public-auth-default
-  # - public-auth-iam public-auth-iam
-  # - owner-custom-claim-default owner-custom-claim-default
+  - owner-based-default owner-based-default # TODO: Add `owner-based-operations` when tests pass
+  - static-user-pool-groups-default static-user-pool-groups-default
+  - static-user-pool-groups-operations static-user-pool-groups-operations
+  - owner-and-group-different-models-default owner-and-group-different-models-default
+  - owner-and-group-same-model-default owner-and-group-same-model-default
+  - owner-and-group-same-model-operations owner-and-group-same-model-operations
+  - dynamic-user-pool-groups-default dynamic-user-pool-groups-default
+  - dynamic-user-pool-groups-owner-based-default dynamic-user-pool-groups-owner-based-default
+  - private-auth-default private-auth-default
+  - private-auth-iam private-auth-iam
+  - public-auth-default public-auth-default
+  - public-auth-iam public-auth-iam
+  - owner-custom-claim-default owner-custom-claim-default
   - owner-custom-field-default owner-custom-field-default
-

--- a/.github/integ-config/utils.yml
+++ b/.github/integ-config/utils.yml
@@ -1,7 +1,25 @@
 minimal_browser_list:
   - chrome
   - firefox
+
 extended_browser_list:
   - chrome
   - firefox
   - edge
+
+datastore_auth_scenarios_sample_spec:
+  # - owner-based-default owner-based-default # TODO: Add `owner-based-operations` when tests pass
+  # - static-user-pool-groups-default static-user-pool-groups-default
+  # - static-user-pool-groups-operations static-user-pool-groups-operations
+  # - owner-and-group-different-models-default owner-and-group-different-models-default
+  # - owner-and-group-same-model-default owner-and-group-same-model-default
+  # - owner-and-group-same-model-operations owner-and-group-same-model-operations
+  # - dynamic-user-pool-groups-default dynamic-user-pool-groups-default
+  # - dynamic-user-pool-groups-owner-based-default dynamic-user-pool-groups-owner-based-default
+  # - private-auth-default private-auth-default
+  # - private-auth-iam private-auth-iam
+  # - public-auth-default public-auth-default
+  # - public-auth-iam public-auth-iam
+  # - owner-custom-claim-default owner-custom-claim-default
+  - owner-custom-field-default owner-custom-field-default
+

--- a/.github/workflows/callable-e2e-runner.yml
+++ b/.github/workflows/callable-e2e-runner.yml
@@ -34,9 +34,22 @@ jobs:
       test_name: ${{ matrix.integ-config.test_name }}
       framework: ${{ matrix.integ-config.framework }}
       category: ${{ matrix.integ-config.category }}
-      sample_name: ${{ matrix.integ-config.sample_name }}
       spec: ${{ matrix.integ-config.spec }}
       amplifyjs_dir: ${{ matrix.integ-config.amplifyjs_dir || false }}
+      sample_name: |
+        ${{
+          fromJson(
+            needs.e2e-prep.outputs.integ-utils
+          )[matrix.integ-config.sample_name]
+          &&
+          toJSON(
+            fromJson(
+              needs.e2e-prep.outputs.integ-utils
+            )[matrix.integ-config.sample_name]
+          )
+          ||
+          format('[{0}]', toJSON(matrix.integ-config.sample_name))
+        }}
       browser: |
         ${{
           fromJson(

--- a/.github/workflows/callable-e2e-tests.yml
+++ b/.github/workflows/callable-e2e-tests.yml
@@ -42,6 +42,8 @@ jobs:
       matrix:
         browser:
           - ${{ fromJson(inputs.browser) }}
+        sample_name:
+          - ${{ fromJson(inputs.sample_name) }}
       fail-fast: false
     timeout-minutes: 20
 
@@ -51,7 +53,7 @@ jobs:
           echo \
           "${{ inputs.framework }} \
           ${{ inputs.category }} \
-          ${{ inputs.sample_name }} \
+          ${{ matrix.sample_name }} \
           ${{ inputs.spec }} \
           ${{ matrix.browser }} \
           ${{ inputs.amplifyjs_dir }}"
@@ -72,13 +74,13 @@ jobs:
       - name: Run cypress tests for ${{ inputs.test_name }} dev
         run: |
           ../aws-amplify/.circleci/retry-yarn-script.sh -s \
-          "ci:test ${{ inputs.framework }} ${{ inputs.category }} ${{ inputs.sample_name }} ${{ inputs.spec }} ${{ matrix.browser }} dev ${{ inputs.amplifyjs_dir == true && env.AMPLIFY_DIR || ''}}" -n 3
+          "ci:test ${{ inputs.framework }} ${{ inputs.category }} ${{ matrix.sample_name }} ${{ inputs.spec }} ${{ matrix.browser }} dev ${{ inputs.amplifyjs_dir == true && env.AMPLIFY_DIR || ''}}" -n 3
         working-directory: amplify-js-samples-staging
         shell: bash
       - name: Run cypress tests for ${{ inputs.test_name }} prod
         run: |
           ../aws-amplify/.circleci/retry-yarn-script.sh -s \
-          "ci:test ${{ inputs.framework }} ${{ inputs.category }} ${{ inputs.sample_name }} ${{ inputs.spec }} ${{ matrix.browser }} prod ${{ inputs.amplifyjs_dir == true && env.AMPLIFY_DIR || ''}}" -n 3
+          "ci:test ${{ inputs.framework }} ${{ inputs.category }} ${{ matrix.sample_name }} ${{ inputs.spec }} ${{ matrix.browser }} prod ${{ inputs.amplifyjs_dir == true && env.AMPLIFY_DIR || ''}}" -n 3
         working-directory: amplify-js-samples-staging
         shell: bash
 # TODO CODE FROM CIRCLE CI: REPLICATE THIS


### PR DESCRIPTION
#### Description of changes
- Add additional datastore tests
- These tests require `sample_name` and `spec` to be passed dynamically from an external array
- one way of achieving required solution is to mention `sample_name / spec` combo in utility.yml. And then pass this in 
  - either use utility.yml combo it in `sample_name` and providing empty `spec` (current approach)
  - OR using it in `spec` and providing empty `sample_name`

#### Issue #, if available



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
