### PR TITLE
chore: Revert to relative path use

### DIFF
--- a/.github/workflows/callable-bundle-size-tests.yml
+++ b/.github/workflows/callable-bundle-size-tests.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 2
           path: amplify-js
       - name: Setup node and build the repository
-        uses: stocaaro/amplify-js/.github/actions/node-and-build@main
+        uses: ./amplify-js/.github/actions/node-and-build
       - name: Run Bundle Size Tests
         working-directory: ./amplify-js
         run: yarn test:size

--- a/.github/workflows/callable-e2e-runner.yml
+++ b/.github/workflows/callable-e2e-runner.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         integ-config: ${{ fromJson(needs.e2e-prep.outputs.integ-config) }}
       fail-fast: false
-    uses: stocaaro/amplify-js/.github/workflows/callable-e2e-tests.yml@main
+    uses: ./amplify-js/.github/workflows/callable-e2e-tests.yml
     with:
       test_name: ${{ matrix.integ-config.test_name }}
       framework: ${{ matrix.integ-config.framework }}
@@ -50,7 +50,7 @@ jobs:
         integ-config: ${{ fromJson(needs.e2e-prep.outputs.detox-integ-config) }}
       fail-fast: false
     secrets: inherit
-    uses: stocaaro/amplify-js/.github/workflows/callable-e2e-tests-detox.yml@main
+    uses: ./amplify-js/.github/workflows/callable-e2e-tests-detox.yml
     with:
       test_name: ${{ matrix.integ-config.test_name }}
       working_directory: ${{ matrix.integ-config.working_directory }}

--- a/.github/workflows/callable-e2e-runner.yml
+++ b/.github/workflows/callable-e2e-runner.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         integ-config: ${{ fromJson(needs.e2e-prep.outputs.integ-config) }}
       fail-fast: false
-    uses: ./amplify-js/.github/workflows/callable-e2e-tests.yml
+    uses: ./.github/workflows/callable-e2e-tests.yml
     with:
       test_name: ${{ matrix.integ-config.test_name }}
       framework: ${{ matrix.integ-config.framework }}
@@ -50,7 +50,7 @@ jobs:
         integ-config: ${{ fromJson(needs.e2e-prep.outputs.detox-integ-config) }}
       fail-fast: false
     secrets: inherit
-    uses: ./amplify-js/.github/workflows/callable-e2e-tests-detox.yml
+    uses: ./.github/workflows/callable-e2e-tests-detox.yml
     with:
       test_name: ${{ matrix.integ-config.test_name }}
       working_directory: ${{ matrix.integ-config.working_directory }}

--- a/.github/workflows/callable-e2e-tests-detox.yml
+++ b/.github/workflows/callable-e2e-tests-detox.yml
@@ -32,13 +32,13 @@ jobs:
           fetch-depth: 2
           path: amplify-js
       - name: Setup node and build the repository
-        uses: stocaaro/amplify-js/.github/actions/node-and-build@main
+        uses: ./amplify-js/.github/actions/node-and-build
       - name: Setup samples staging repository
-        uses: stocaaro/amplify-js/.github/actions/setup-samples-staging@main
+        uses: ./amplify-js/.github/actions/setup-samples-staging
         with:
           GH_PAT: ${{ secrets.GH_PAT }}
       - name: Load Verdaccio with AmplifyJs
-        uses: stocaaro/amplify-js/.github/actions/load-verdaccio-with-amplify-js@main
+        uses: ./amplify-js/.github/actions/load-verdaccio-with-amplify-js
       - name: Yarn Install
         working-directory: ${{ inputs.working_directory }}
         run: |

--- a/.github/workflows/callable-e2e-tests.yml
+++ b/.github/workflows/callable-e2e-tests.yml
@@ -65,13 +65,13 @@ jobs:
           fetch-depth: 2
           path: amplify-js
       - name: Setup node and build the repository
-        uses: stocaaro/amplify-js/.github/actions/node-and-build@main
+        uses: ./amplify-js/.github/actions/node-and-build
       - name: Setup samples staging repository
-        uses: stocaaro/amplify-js/.github/actions/setup-samples-staging@main
+        uses: ./amplify-js/.github/actions/setup-samples-staging
         with:
           GH_PAT: ${{ secrets.GH_PAT }}
       - name: Load Verdaccio with AmplifyJs
-        uses: stocaaro/amplify-js/.github/actions/load-verdaccio-with-amplify-js@main
+        uses: ./amplify-js/.github/actions/load-verdaccio-with-amplify-js
       - name: Run cypress tests for ${{ inputs.test_name }} dev
         run: |
           ../amplify-js/.circleci/retry-yarn-script.sh -s \

--- a/.github/workflows/callable-e2e.yml
+++ b/.github/workflows/callable-e2e.yml
@@ -5,25 +5,25 @@ on:
 
 jobs:
   prebuild-ubuntu:
-    uses: stocaaro/amplify-js/.github/workflows/callable-prebuild-amplify-js.yml@main
+    uses: ./amplify-js/.github/workflows/callable-prebuild-amplify-js.yml
     with:
       runs_on: ubuntu-latest
   prebuild-macos:
-    uses: stocaaro/amplify-js/.github/workflows/callable-prebuild-amplify-js.yml@main
+    uses: ./amplify-js/.github/workflows/callable-prebuild-amplify-js.yml
     with:
       runs_on: macos-latest
   prebuild-samples-staging:
     secrets: inherit
-    uses: stocaaro/amplify-js/.github/workflows/callable-prebuild-samples-staging.yml@main
+    uses: ./amplify-js/.github/workflows/callable-prebuild-samples-staging.yml
   e2e:
     needs:
       - prebuild-macos
       - prebuild-ubuntu
       - prebuild-samples-staging
     secrets: inherit
-    uses: stocaaro/amplify-js/.github/workflows/callable-e2e-runner.yml@main
+    uses: ./amplify-js/.github/workflows/callable-e2e-runner.yml
   get-package-list:
-    uses: stocaaro/amplify-js/.github/workflows/callable-get-package-list.yml@main
+    uses: ./amplify-js/.github/workflows/callable-get-package-list.yml
   unit-tests:
     needs:
       - prebuild-ubuntu
@@ -32,9 +32,9 @@ jobs:
       matrix:
         package: ${{ fromJSON(needs.get-package-list.outputs.packages) }}
       fail-fast: false
-    uses: stocaaro/amplify-js/.github/workflows/callable-unit-tests.yml@main
+    uses: ./amplify-js/.github/workflows/callable-unit-tests.yml
     with:
       package: ${{ matrix.package }}
   bundle-size-tests:
     needs: prebuild-ubuntu
-    uses: stocaaro/amplify-js/.github/workflows/callable-bundle-size-tests.yml@main
+    uses: ./amplify-js/.github/workflows/callable-bundle-size-tests.yml

--- a/.github/workflows/callable-e2e.yml
+++ b/.github/workflows/callable-e2e.yml
@@ -5,25 +5,25 @@ on:
 
 jobs:
   prebuild-ubuntu:
-    uses: ./amplify-js/.github/workflows/callable-prebuild-amplify-js.yml
+    uses: ./.github/workflows/callable-prebuild-amplify-js.yml
     with:
       runs_on: ubuntu-latest
   prebuild-macos:
-    uses: ./amplify-js/.github/workflows/callable-prebuild-amplify-js.yml
+    uses: ./.github/workflows/callable-prebuild-amplify-js.yml
     with:
       runs_on: macos-latest
   prebuild-samples-staging:
     secrets: inherit
-    uses: ./amplify-js/.github/workflows/callable-prebuild-samples-staging.yml
+    uses: ./.github/workflows/callable-prebuild-samples-staging.yml
   e2e:
     needs:
       - prebuild-macos
       - prebuild-ubuntu
       - prebuild-samples-staging
     secrets: inherit
-    uses: ./amplify-js/.github/workflows/callable-e2e-runner.yml
+    uses: ./.github/workflows/callable-e2e-runner.yml
   get-package-list:
-    uses: ./amplify-js/.github/workflows/callable-get-package-list.yml
+    uses: ./.github/workflows/callable-get-package-list.yml
   unit-tests:
     needs:
       - prebuild-ubuntu
@@ -32,9 +32,9 @@ jobs:
       matrix:
         package: ${{ fromJSON(needs.get-package-list.outputs.packages) }}
       fail-fast: false
-    uses: ./amplify-js/.github/workflows/callable-unit-tests.yml
+    uses: ./.github/workflows/callable-unit-tests.yml
     with:
       package: ${{ matrix.package }}
   bundle-size-tests:
     needs: prebuild-ubuntu
-    uses: ./amplify-js/.github/workflows/callable-bundle-size-tests.yml
+    uses: ./.github/workflows/callable-bundle-size-tests.yml

--- a/.github/workflows/callable-npm-publish.yml
+++ b/.github/workflows/callable-npm-publish.yml
@@ -34,12 +34,12 @@ jobs:
           fetch-depth: 2
           path: amplify-js
       - name: Setup node and build the repository
-        uses: stocaaro/amplify-js/.github/actions/node-and-build@main
+        uses: ./amplify-js/.github/actions/node-and-build
       ###
       # TODO Remove this to enable real NPM interactions.
       # <remove>
       - name: Load Verdaccio with AmplifyJs
-        uses: stocaaro/amplify-js/.github/actions/load-verdaccio-with-amplify-js@main
+        uses: ./amplify-js/.github/actions/load-verdaccio-with-amplify-js
       ### </remove>
 
       - name: Run npm publish

--- a/.github/workflows/callable-prebuild-amplify-js.yml
+++ b/.github/workflows/callable-prebuild-amplify-js.yml
@@ -18,6 +18,6 @@ jobs:
           fetch-depth: 2
           path: amplify-js
       - name: Setup node and build the repository
-        uses: stocaaro/amplify-js/.github/actions/node-and-build@main
+        uses: ./amplify-js/.github/actions/node-and-build
         with:
           is-prebuild: true

--- a/.github/workflows/callable-prebuild-samples-staging.yml
+++ b/.github/workflows/callable-prebuild-samples-staging.yml
@@ -16,6 +16,6 @@ jobs:
           fetch-depth: 2
           path: amplify-js
       - name: Setup samples staging
-        uses: stocaaro/amplify-js/.github/actions/setup-samples-staging@main
+        uses: ./amplify-js/.github/actions/setup-samples-staging
         with:
           GH_PAT: ${{ secrets.GH_PAT }}

--- a/.github/workflows/callable-preid-release.yml
+++ b/.github/workflows/callable-preid-release.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   release-to-preid:
-    uses: stocaaro/amplify-js/.github/workflows/callable-npm-publish.yml@main
+    uses: ./amplify-js/.github/workflows/callable-npm-publish.yml
     with:
       target: preid
       preid: ${{ inputs.preid }}

--- a/.github/workflows/callable-preid-release.yml
+++ b/.github/workflows/callable-preid-release.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   release-to-preid:
-    uses: ./amplify-js/.github/workflows/callable-npm-publish.yml
+    uses: ./.github/workflows/callable-npm-publish.yml
     with:
       target: preid
       preid: ${{ inputs.preid }}

--- a/.github/workflows/callable-release.yml
+++ b/.github/workflows/callable-release.yml
@@ -5,6 +5,6 @@ on:
 
 jobs:
   release-latest:
-    uses: stocaaro/amplify-js/.github/workflows/callable-npm-publish.yml@main
+    uses: ./amplify-js/.github/workflows/callable-npm-publish.yml
     with:
       target: release

--- a/.github/workflows/callable-release.yml
+++ b/.github/workflows/callable-release.yml
@@ -5,6 +5,6 @@ on:
 
 jobs:
   release-latest:
-    uses: ./amplify-js/.github/workflows/callable-npm-publish.yml
+    uses: ./.github/workflows/callable-npm-publish.yml
     with:
       target: release

--- a/.github/workflows/callable-unit-tests.yml
+++ b/.github/workflows/callable-unit-tests.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 2
           path: amplify-js
       - name: Setup node and build the repository
-        uses: stocaaro/amplify-js/.github/actions/node-and-build@main
+        uses: ./amplify-js/.github/actions/node-and-build
       - name: Run tests
         working-directory: ./amplify-js
         run: npx lerna exec --scope ${{ inputs.package }} yarn test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,13 +18,13 @@ jobs:
           fetch-depth: 2
           path: amplify-js
       - name: Setup node and build the repository
-        uses: stocaaro/amplify-js/.github/actions/node-and-build@main
+        uses: ./amplify-js/.github/actions/node-and-build
         with:
           is-prebuild: true
   get-package-list:
-    uses: stocaaro/amplify-js/.github/workflows/callable-get-package-list.yml@main
+    uses: ./amplify-js/.github/workflows/callable-get-package-list.yml
   codeql:
-    uses: stocaaro/amplify-js/.github/workflows/callable-codeql.yml@main
+    uses: ./amplify-js/.github/workflows/callable-codeql.yml
   unit-tests:
     needs:
       - prebuild
@@ -33,9 +33,9 @@ jobs:
       matrix:
         package: ${{ fromJSON(needs.get-package-list.outputs.packages) }}
       fail-fast: false
-    uses: stocaaro/amplify-js/.github/workflows/callable-unit-tests.yml@main
+    uses: ./amplify-js/.github/workflows/callable-unit-tests.yml
     with:
       package: ${{ matrix.package }}
   bundle-size-tests:
     needs: prebuild
-    uses: stocaaro/amplify-js/.github/workflows/callable-bundle-size-tests.yml@main
+    uses: ./amplify-js/.github/workflows/callable-bundle-size-tests.yml

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,9 +22,9 @@ jobs:
         with:
           is-prebuild: true
   get-package-list:
-    uses: ./amplify-js/.github/workflows/callable-get-package-list.yml
+    uses: ./.github/workflows/callable-get-package-list.yml
   codeql:
-    uses: ./amplify-js/.github/workflows/callable-codeql.yml
+    uses: ./.github/workflows/callable-codeql.yml
   unit-tests:
     needs:
       - prebuild
@@ -33,9 +33,9 @@ jobs:
       matrix:
         package: ${{ fromJSON(needs.get-package-list.outputs.packages) }}
       fail-fast: false
-    uses: ./amplify-js/.github/workflows/callable-unit-tests.yml
+    uses: ./.github/workflows/callable-unit-tests.yml
     with:
       package: ${{ matrix.package }}
   bundle-size-tests:
     needs: prebuild
-    uses: ./amplify-js/.github/workflows/callable-bundle-size-tests.yml
+    uses: ./.github/workflows/callable-bundle-size-tests.yml

--- a/.github/workflows/push-integ-test.yml
+++ b/.github/workflows/push-integ-test.yml
@@ -9,4 +9,4 @@ on:
 jobs:
   e2e:
     secrets: inherit
-    uses: stocaaro/amplify-js/.github/workflows/callable-e2e.yml@main
+    uses: ./amplify-js/.github/workflows/callable-e2e.yml

--- a/.github/workflows/push-integ-test.yml
+++ b/.github/workflows/push-integ-test.yml
@@ -9,4 +9,4 @@ on:
 jobs:
   e2e:
     secrets: inherit
-    uses: ./amplify-js/.github/workflows/callable-e2e.yml
+    uses: ./.github/workflows/callable-e2e.yml

--- a/.github/workflows/push-latest-release.yml
+++ b/.github/workflows/push-latest-release.yml
@@ -8,9 +8,9 @@ on:
 jobs:
   e2e:
     secrets: inherit
-    uses: stocaaro/amplify-js/.github/workflows/callable-e2e.yml@main
+    uses: ./amplify-js/.github/workflows/callable-e2e.yml
   release:
     needs:
       - e2e
     secrets: inherit
-    uses: stocaaro/amplify-js/.github/workflows/callable-release.yml@main
+    uses: ./amplify-js/.github/workflows/callable-release.yml

--- a/.github/workflows/push-latest-release.yml
+++ b/.github/workflows/push-latest-release.yml
@@ -8,9 +8,9 @@ on:
 jobs:
   e2e:
     secrets: inherit
-    uses: ./amplify-js/.github/workflows/callable-e2e.yml
+    uses: ./.github/workflows/callable-e2e.yml
   release:
     needs:
       - e2e
     secrets: inherit
-    uses: ./amplify-js/.github/workflows/callable-release.yml
+    uses: ./.github/workflows/callable-release.yml

--- a/.github/workflows/push-main-release.yml
+++ b/.github/workflows/push-main-release.yml
@@ -8,11 +8,11 @@ on:
 jobs:
   e2e:
     secrets: inherit
-    uses: ./amplify-js/.github/workflows/callable-e2e.yml
+    uses: ./.github/workflows/callable-e2e.yml
   unstable-release:
     needs:
       - e2e
     secrets: inherit
-    uses: ./amplify-js/.github/workflows/callable-preid-release.yml
+    uses: ./.github/workflows/callable-preid-release.yml
     with:
       preid: unstable

--- a/.github/workflows/push-main-release.yml
+++ b/.github/workflows/push-main-release.yml
@@ -8,11 +8,11 @@ on:
 jobs:
   e2e:
     secrets: inherit
-    uses: stocaaro/amplify-js/.github/workflows/callable-e2e.yml@main
+    uses: ./amplify-js/.github/workflows/callable-e2e.yml
   unstable-release:
     needs:
       - e2e
     secrets: inherit
-    uses: stocaaro/amplify-js/.github/workflows/callable-preid-release.yml@main
+    uses: ./amplify-js/.github/workflows/callable-preid-release.yml
     with:
       preid: unstable

--- a/.github/workflows/push-preid-release.yml
+++ b/.github/workflows/push-preid-release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   e2e:
     secrets: inherit
-    uses: ./amplify-js/.github/workflows/callable-e2e.yml
+    uses: ./.github/workflows/callable-e2e.yml
   parse-preid:
     name: 'Parse preid from branch'
     runs-on: ubuntu-latest
@@ -26,7 +26,7 @@ jobs:
       - e2e
       - parse-preid
     secrets: inherit
-    uses: ./amplify-js/.github/workflows/callable-preid-release.yml
+    uses: ./.github/workflows/callable-preid-release.yml
     # The preid should be detected from th branch name recommending feat/PREID/whatvever as branch naming pattern
     with:
       preid: ${{ needs.parse-preid.outputs.preid }}

--- a/.github/workflows/push-preid-release.yml
+++ b/.github/workflows/push-preid-release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   e2e:
     secrets: inherit
-    uses: stocaaro/amplify-js/.github/workflows/callable-e2e.yml@main
+    uses: ./amplify-js/.github/workflows/callable-e2e.yml
   parse-preid:
     name: 'Parse preid from branch'
     runs-on: ubuntu-latest
@@ -26,7 +26,7 @@ jobs:
       - e2e
       - parse-preid
     secrets: inherit
-    uses: stocaaro/amplify-js/.github/workflows/callable-preid-release.yml@main
+    uses: ./amplify-js/.github/workflows/callable-preid-release.yml
     # The preid should be detected from th branch name recommending feat/PREID/whatvever as branch naming pattern
     with:
       preid: ${{ needs.parse-preid.outputs.preid }}


### PR DESCRIPTION
#### Description of changes
There are examples of relative path vs repo scoped uses statements. Transitioning to using relative paths exclusively since its easier to track the current versions than working with cross branch inconsistencies.


#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
