### PR TITLE
chore: run e2e Rollup + DataStore test on just chrome

### DIFF
--- a/.github/integ-config/integ-all.yml
+++ b/.github/integ-config/integ-all.yml
@@ -436,7 +436,8 @@ tests:
     category: datastore
     sample_name: [rollup-basic-crud]
     spec: rollup-basic-crud
-    browser: *minimal_browser_list
+    # TODO: run on firefox
+    browser: [chrome]
     timeout_minutes: 45
     retry_count: 10
 


### PR DESCRIPTION
#### Description of changes
- run e2e Rollup + DataStore test on just chrome
- on firefox it is highly indeterministic 

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->



#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
