### PR TITLE
chore: add concurrency to push workflows

### DIFF
--- a/.github/workflows/push-integ-test.yml
+++ b/.github/workflows/push-integ-test.yml
@@ -1,3 +1,10 @@
+name: Push - run all checks prior to release, doesn't release
+
+concurrency:
+  # group name unique for push to push-integ-test
+  group: push-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:

--- a/.github/workflows/push-integ-test.yml
+++ b/.github/workflows/push-integ-test.yml
@@ -1,4 +1,4 @@
-name: Push - run all checks prior to release, doesn't release
+name: Push - run release verifications
 
 concurrency:
   # group name unique for push to push-integ-test

--- a/.github/workflows/push-latest-release.yml
+++ b/.github/workflows/push-latest-release.yml
@@ -1,5 +1,10 @@
 name: Push - release from release to latest
 
+concurrency:
+  # group name unique for push to push-latest-release
+  group: push-release-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:

--- a/.github/workflows/push-main-release.yml
+++ b/.github/workflows/push-main-release.yml
@@ -1,5 +1,10 @@
 name: Push - release from main to unstable
 
+concurrency:
+  # group name unique for push to push-main-release
+  group: push-release-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:

--- a/.github/workflows/push-preid-release.yml
+++ b/.github/workflows/push-preid-release.yml
@@ -1,5 +1,10 @@
 name: Push - release for feature preid
 
+concurrency:
+  # group name unique for push to push-preid-release
+  group: push-release-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:


### PR DESCRIPTION
#### Description of changes
Add concurrency to push workflows
- push-main-release
- push-latest-release
- push-preid-release
- push-integ-test

we use `${{ github.ref }}` which gives us refs/heads/feat/github-actions/<branch_name_pushed_to>

#### Issue #, if available
<!-- Also, please reference any associated PRs for documentation updates. -->


#### Description of how you validated changes



#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
