### PR TITLE
chore: Add preid protection

### DIFF
--- a/.github/workflows/callable-npm-publish-preid.yml
+++ b/.github/workflows/callable-npm-publish-preid.yml
@@ -6,6 +6,10 @@ on:
       preid:
         required: false
         type: string
+      allow-protected-preid:
+        required: false
+        default: false
+        type: boolean
 
 # TODO: configure these env variables
 env:
@@ -17,6 +21,20 @@ jobs:
     name: Publish to Amplify Package
     runs-on: ubuntu-latest
     steps:
+      - name: Forbidden and protected preid protection
+        # Protection for npm tags that we want to protect from accidental use
+        env:
+          ALLOW_PROTECTED_PREIDS: ${{ inputs.allow-protected-preid }}
+          PREID: ${{ inputs.preid }}
+          FORBIDDEN_PREIDS: latest
+          PROTECTED_PREIDS: next unstable
+        run: |
+          echo "Testing to see if $PREID is in the forbidden list ($FORBIDDEN_PREIDS)"
+          for e in $FORBIDDEN_PREIDS; do [[ $PREID == $e ]] && echo "$PREID is forbidden from preid release" && exit 1; done
+          [[ $ALLOW_PROTECTED_PREIDS == 'false' ]] && echo "Testing to see if $PREID is in the protected list ($PROTECTED_PREIDS)"
+          [[ $ALLOW_PROTECTED_PREIDS == 'false' ]] && for e in $PROTECTED_PREIDS; do [[ $PREID == $e ]] && echo "$PREID is protected from preid release" && exit 1; done
+          echo "$PREID is allowed for preid release"
+
       - name: Checkout repository
         uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,7 +7,8 @@ on:
   pull_request:
     branches: ['main']
   schedule:
-    - cron: '28 21 * * 2'
+    # Run every Tuesday at midnight GMT
+    - cron: '0 0 * * 2'
 
 jobs:
   analyze:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,8 @@ concurrency:
 
 on: pull_request
 
+permissions: read-all
+
 jobs:
   prebuild:
     runs-on: ubuntu-latest

--- a/.github/workflows/push-main-release.yml
+++ b/.github/workflows/push-main-release.yml
@@ -16,3 +16,4 @@ jobs:
     uses: ./.github/workflows/callable-npm-publish-preid.yml
     with:
       preid: unstable
+      allow-protected-preid: true


### PR DESCRIPTION
#### Description of changes
From our cross team review, we want to make sure that having convenient preid workflows don't accidentally lead to merges to `latest`, `next`, `unstable` tagged releases.

Includes a clarification to the cron and a permissions refinement recommended by Travis.

This change will error any preid release to `latest` and will require that preid release for `main` and `next` will block unless the user passes `allow-protected-preid: true`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)
- [ ] Relevant documentation is changed or added (and PR referenced)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
