### PR TITLE
fix(datastore): Update outbox comparison logic to fix update versioning problems

### DIFF
--- a/packages/datastore/__tests__/conflictResolutionBehavior.test.ts
+++ b/packages/datastore/__tests__/conflictResolutionBehavior.test.ts
@@ -106,13 +106,13 @@ describe('DataStore sync engine', () => {
 							['post title 0', 1],
 							['post title 1', 1],
 							['post title 2', 1],
-							['post title 0', 3],
-							['post title 0', 3],
+							['post title 2', 3],
+							['post title 2', 3],
 						]);
 
 						expect(await postHarness.currentContents).toMatchObject({
 							_version: 3,
-							title: 'post title 0',
+							title: 'post title 2',
 						});
 					});
 					test('fast connection speed, low latency where we wait for the create to clear the outbox', async () => {
@@ -146,12 +146,12 @@ describe('DataStore sync engine', () => {
 							['post title 0', 1],
 							['post title 1', 1],
 							['post title 2', 1],
-							['post title 0', 4],
+							['post title 2', 4],
 						]);
 
 						expect(await postHarness.currentContents).toMatchObject({
 							_version: 4,
-							title: 'post title 0',
+							title: 'post title 2',
 						});
 					});
 					test('slow connection speed, high latency where we DO NOT wait for the create to clear the outbox', async () => {
@@ -772,7 +772,7 @@ describe('DataStore sync engine', () => {
 						await postHarness.revise('post title 2');
 
 						await harness.outboxSettled();
-						await harness.expectUpdateCallCount(3);
+						await harness.expectUpdateCallCount(2);
 
 						expect(harness.subscriptionLogs()).toEqual([
 							['original title', 1],
@@ -813,7 +813,7 @@ describe('DataStore sync engine', () => {
 						await postHarness.revise('post title 2');
 
 						await harness.outboxSettled();
-						await harness.expectUpdateCallCount(4);
+						await harness.expectUpdateCallCount(3);
 
 						expect(harness.subscriptionLogs()).toEqual([
 							['original title', 1],
@@ -1034,7 +1034,7 @@ describe('DataStore sync engine', () => {
 							await postHarness.revise('post title 2');
 
 							await harness.outboxSettled();
-							await harness.expectUpdateCallCount(5);
+							await harness.expectUpdateCallCount(4);
 
 							expect(harness.subscriptionLogs()).toEqual([
 								['original title', 1],
@@ -1315,7 +1315,7 @@ describe('DataStore sync engine', () => {
 							}
 							await postHarness.revise('post title 2');
 							await harness.outboxSettled();
-							await harness.expectUpdateCallCount(5);
+							await harness.expectUpdateCallCount(4);
 							expect(
 								harness.subscriptionLogs(['title', 'blogId', '_version'])
 							).toEqual([
@@ -1323,13 +1323,13 @@ describe('DataStore sync engine', () => {
 								['post title 0', 'original blogId', 1],
 								['post title 1', 'original blogId', 1],
 								['post title 2', 'original blogId', 1],
-								['post title 2', null, 4],
+								['post title 2', 'original blogId', 4],
 							]);
 
 							expect(await postHarness.currentContents).toMatchObject({
 								_version: 4,
 								title: 'post title 2',
-								blogId: null,
+								blogId: 'original blogId',
 							});
 						});
 						test('slow connection speed, high latency where we wait for all mutations to clear the outbox', async () => {

--- a/packages/datastore/src/sync/outbox.ts
+++ b/packages/datastore/src/sync/outbox.ts
@@ -15,7 +15,7 @@ import {
 	QueryOne,
 	SchemaModel,
 } from '../types';
-import { USER, SYNC, valuesEqual } from '../util';
+import { USER, SYNC, objectMatches } from '../util';
 import { getIdentifierValue, TransformerMutationType } from './utils';
 
 // TODO: Persist deleted ids
@@ -193,10 +193,12 @@ class MutationEventOutbox {
 		// Don't sync the version when the data in the response does not match the data
 		// in the request, i.e., when there's a handled conflict
 		//
-		// NOTE: `incomingData` contains all the fields in the record, and `outgoingData`
-		// only contains updated fields, resulting in an error when doing a comparison
-		// of two equal mutations. Fix this, or mitigate otherwise.
-		if (!valuesEqual(incomingData, outgoingData, true)) {
+		// NOTE: `incomingData` contains all the fields in the record received from AppSync
+		// and `outgoingData` only contains updated fields sent to AppSync
+		// If all send data isn't matched in the returned data then the update was rejected
+		// by AppSync and we should not update the version on other outbox entries for this
+		// object
+		if (!objectMatches(outgoingData, incomingData, true)) {
 			return;
 		}
 

--- a/packages/datastore/src/util.ts
+++ b/packages/datastore/src/util.ts
@@ -473,6 +473,32 @@ export function sortCompareFunction<T extends PersistentModel>(
 	};
 }
 
+/* deep directed comparison ensuring that all fields on object A exist and are equal to values on object B
+ * Note: This same guarauntee is not applied for values on object B that aren't on object A
+ *
+ * @param valA - The object that may be an equal subset of valB.
+ * @param valB - The object that may be an equal superset of valA.
+ * @returns True if valA is a equal subset of valB and False otherwise.
+ */
+export function objectMatches(
+	valA: object,
+	valB: object,
+	nullish: boolean = false
+) {
+	const aKeys = Object.keys(valA);
+
+	for (const key of aKeys) {
+		const aVal = valA[key];
+		const bVal = valB[key];
+
+		if (!valuesEqual(aVal, bVal, nullish)) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
 // deep compare any 2 values
 // primitives or object types (including arrays, Sets, and Maps)
 // returns true if equal by value


### PR DESCRIPTION
#### Description of changes
Outcome:
- To allow multiple partial updates, outbox checks compare all updated fields for deep equality with the returned object, but ignore extra returned fields when gating outbox `_version` maintenance.
- As a result, our rapid update use-cases will not drop updates


#### Issue #, if available


#### Description of how you validated changes
Validated by updating tests and testing against sample apps manaully for both Automerge and OCC usecases

#### Related changes
1. https://github.com/aws-amplify/amplify-js/pull/12728
2. https://github.com/aws-amplify/amplify-js/pull/12732
3. https://github.com/aws-amplify/amplify-js/pull/12740
4. https://github.com/aws-amplify/amplify-js/pull/12795
6. :seedling:  **fix(datastore): Update outbox comparison logic to fix update versioning problems**

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
