### PR TITLE
test(datastore): Add OptimisticConcurrency tests

### DIFF
--- a/packages/datastore/__tests__/conflictResolutionBehavior.test.ts
+++ b/packages/datastore/__tests__/conflictResolutionBehavior.test.ts
@@ -472,7 +472,7 @@ describe('DataStore sync engine', () => {
 							blogId: 'update from second client',
 						});
 					});
-					test('no input delay, high latency where we wait for the create to clear the outbox', async () => {
+					test('no input delay, high latency where we wait for the create to clear the outbox with pause to change sequence', async () => {
 						const postHarness = await harness.createPostHarness({
 							title: 'original title',
 						});
@@ -1135,7 +1135,7 @@ describe('DataStore sync engine', () => {
 							title: 'post title 2',
 						});
 					});
-					test('no input delay, high latency where we wait for the create to clear the outbox', async () => {
+					test('no input delay, high latency where we wait for the create to clear the outbox with pause to change sequence', async () => {
 						const postHarness = await harness.createPostHarness({
 							title: 'original title',
 						});

--- a/packages/datastore/__tests__/conflictResolutionBehavior.test.ts
+++ b/packages/datastore/__tests__/conflictResolutionBehavior.test.ts
@@ -1,6 +1,44 @@
-import { warpTime, unwarpTime, pause } from './helpers';
+import { warpTime, unwarpTime, pause, occRejectionError } from './helpers';
 import { UpdateSequenceHarness } from './helpers/UpdateSequenceHarness';
 
+/**
+ * NOTE:
+ * The following test assertions are based on *existing* behavior, not *correct*
+ * behavior. Once we have fixed rapid single-field consecutive updates, and updates on a
+ * poor connection, we should update these assertions to reflect the *correct* behavior.
+ *
+ * WHAT WE ARE TESTING:
+ * Test observed rapid single-field mutations with variable connection latencies, as well as
+ * waiting / not waiting on the outbox between mutations. All permutations are necessary,
+ * as each scenario results in different observed behavior - essentially, whether or not
+ * the outbox merges updates. We are updating a single field with each mutation to ensure
+ * that the outbox's `syncOutboxVersionsOnDequeue` does the right value comparison when
+ * there are multiple fields present on a model, but only one is updated.
+ *
+ * NOTE: if these tests fail, and you witness one of the following:
+ *     1) The retry throws an error
+ *     2) The number of observed updates has changed
+ *     3) The record's final version number has changed
+ * make sure you haven't adjusted the artifical latency or `pause` values, as this will
+ * result in a change in the expected number of merges performed by the outbox.
+ *
+ * NOTES ON HOW WE PERFORM CONSECUTIVE UPDATES:
+ *
+ * When we want to test a scenario where the outbox does not necessarily merge all outgoing
+ * requests (for instance, when we do not add artifical latency to the connection), we make
+ * the mutations rapidly (i.e. we don't await the outbox). However, because of how
+ * rapidly the mutations are performed, we are creating an artifical situation where
+ * mutations will always be merged. Adding a slight pause between mutations dds a
+ * semi-realistic pause ("button clicks") between updates. This is not required when awaiting
+ * the outbox after each mutation. Additionally, a pause is not required if we are
+ * intentionally testing rapid updates, such as when the initial save is still pending.
+ *
+ * When we want to test a scenario where the user is waiting for a long period of time
+ * between each mutation (non-concurrent updates), we wait for an empty outbox after each
+ * mutation. This ensures each mutation completes a full cycle before the next mutation
+ * begins. This guarantees that there will NEVER be concurrent updates being processed by
+ * the outbox.
+ */
 describe('DataStore sync engine', () => {
 	let harness: UpdateSequenceHarness;
 
@@ -8,61 +46,24 @@ describe('DataStore sync engine', () => {
 		// we don't need to see all the console warnings for these tests ...
 		(console as any)._warn = console.warn;
 		console.warn = () => {};
-
-		harness = new UpdateSequenceHarness();
-		await harness.startDatastore();
+		warpTime();
 	});
 
 	afterEach(async () => {
-		await harness.destroy();
 		console.warn = (console as any)._warn;
+		unwarpTime();
 	});
-	describe('connection state change handling', () => {
+
+	describe('Automerge conflict resolution', () => {
 		beforeEach(async () => {
-			warpTime();
+			harness = new UpdateSequenceHarness('Automerge');
+			await harness.startDatastore();
 		});
 
 		afterEach(async () => {
-			unwarpTime();
+			await harness.destroy();
 		});
-		/**
-		 * NOTE:
-		 * The following test assertions are based on *existing* behavior, not *correct*
-		 * behavior. Once we have fixed rapid single-field consecutive updates, and updates on a
-		 * poor connection, we should update these assertions to reflect the *correct* behavior.
-		 *
-		 * WHAT WE ARE TESTING:
-		 * Test observed rapid single-field mutations with variable connection latencies, as well as
-		 * waiting / not waiting on the outbox between mutations. All permutations are necessary,
-		 * as each scenario results in different observed behavior - essentially, whether or not
-		 * the outbox merges updates. We are updating a single field with each mutation to ensure
-		 * that the outbox's `syncOutboxVersionsOnDequeue` does the right value comparison when
-		 * there are multiple fields present on a model, but only one is updated.
-		 *
-		 * NOTE: if these tests fail, and you witness one of the following:
-		 *     1) The retry throws an error
-		 *     2) The number of observed updates has changed
-		 *     3) The record's final version number has changed
-		 * make sure you haven't adjusted the artifical latency or `pause` values, as this will
-		 * result in a change in the expected number of merges performed by the outbox.
-		 *
-		 * NOTES ON HOW WE PERFORM CONSECUTIVE UPDATES:
-		 *
-		 * When we want to test a scenario where the outbox does not necessarily merge all outgoing
-		 * requests (for instance, when we do not add artifical latency to the connection), we make
-		 * the mutations rapidly (i.e. we don't await the outbox). However, because of how
-		 * rapidly the mutations are performed, we are creating an artifical situation where
-		 * mutations will always be merged. Adding a slight pause between mutations dds a
-		 * semi-realistic pause ("button clicks") between updates. This is not required when awaiting
-		 * the outbox after each mutation. Additionally, a pause is not required if we are
-		 * intentionally testing rapid updates, such as when the initial save is still pending.
-		 *
-		 * When we want to test a scenario where the user is waiting for a long period of time
-		 * between each mutation (non-concurrent updates), we wait for an empty outbox after each
-		 * mutation. This ensures each mutation completes a full cycle before the next mutation
-		 * begins. This guarantees that there will NEVER be concurrent updates being processed by
-		 * the outbox.
-		 */
+
 		describe('observed rapid single-field mutations with variable connection latencies', () => {
 			describe('single client updates', () => {
 				test('no input delay, high latency where we wait for the create to clear the outbox', async () => {
@@ -80,7 +81,7 @@ describe('DataStore sync engine', () => {
 					await postHarness.revise('post title 2');
 
 					await harness.fullSettle();
-					await harness.expectGraphqlSettledWithUpdateCallCount(2);
+					await harness.expectGraphqlSettledWithEventCount(2);
 
 					expect(harness.subscriptionLogs()).toEqual([
 						['original title', 1],
@@ -110,7 +111,7 @@ describe('DataStore sync engine', () => {
 					await postHarness.revise('post title 2');
 
 					await harness.fullSettle();
-					await harness.expectGraphqlSettledWithUpdateCallCount(3);
+					await harness.expectGraphqlSettledWithEventCount(3);
 
 					expect(harness.subscriptionLogs()).toEqual([
 						['original title', 1],
@@ -141,7 +142,7 @@ describe('DataStore sync engine', () => {
 					await postHarness.revise('post title 2');
 
 					await harness.fullSettle();
-					await harness.expectGraphqlSettledWithUpdateCallCount(0);
+					await harness.expectGraphqlSettledWithEventCount(0);
 
 					expect(harness.subscriptionLogs()).toEqual([
 						['post title 0', undefined],
@@ -175,7 +176,7 @@ describe('DataStore sync engine', () => {
 					await postHarness.revise('post title 2');
 
 					await harness.fullSettle();
-					await harness.expectGraphqlSettledWithUpdateCallCount(0);
+					await harness.expectGraphqlSettledWithEventCount(0);
 
 					expect(harness.subscriptionLogs()).toEqual([
 						['post title 0', undefined],
@@ -208,7 +209,7 @@ describe('DataStore sync engine', () => {
 					await postHarness.revise('post title 1');
 					await postHarness.revise('post title 2');
 
-					await harness.expectGraphqlSettledWithUpdateCallCount(3);
+					await harness.expectGraphqlSettledWithEventCount(3);
 
 					expect(harness.subscriptionLogs()).toEqual([
 						['original title', 1],
@@ -241,7 +242,7 @@ describe('DataStore sync engine', () => {
 					await postHarness.revise('post title 1');
 					await postHarness.revise('post title 2');
 
-					await harness.expectGraphqlSettledWithUpdateCallCount(3);
+					await harness.expectGraphqlSettledWithEventCount(3);
 
 					expect(harness.subscriptionLogs()).toEqual([
 						['original title', 1],
@@ -287,7 +288,7 @@ describe('DataStore sync engine', () => {
 						await postHarness.revise('post title 2');
 
 						await harness.fullSettle();
-						await harness.expectGraphqlSettledWithUpdateCallCount(3);
+						await harness.expectGraphqlSettledWithEventCount(3);
 						expect(harness.subscriptionLogs()).toEqual([
 							['original title', 1],
 							['post title 0', 1],
@@ -321,7 +322,7 @@ describe('DataStore sync engine', () => {
 						await postHarness.revise('post title 2');
 
 						await harness.fullSettle();
-						await harness.expectGraphqlSettledWithUpdateCallCount(4);
+						await harness.expectGraphqlSettledWithEventCount(4);
 
 						expect(harness.subscriptionLogs()).toEqual([
 							['original title', 1],
@@ -356,7 +357,7 @@ describe('DataStore sync engine', () => {
 
 						await postHarness.revise('post title 2');
 
-						await harness.expectGraphqlSettledWithUpdateCallCount(4);
+						await harness.expectGraphqlSettledWithEventCount(4);
 
 						expect(harness.subscriptionLogs()).toEqual([
 							['original title', 1],
@@ -368,7 +369,6 @@ describe('DataStore sync engine', () => {
 							// Note: The subscription event for post title 1
 							// is processed after the second client update
 							// and the updated content is observed (below)
-							['update from second client', 4],
 							['update from second client', 4],
 							['update from second client', 4],
 							['post title 2', 4],
@@ -401,7 +401,7 @@ describe('DataStore sync engine', () => {
 
 						await postHarness.revise('post title 2');
 
-						await harness.expectGraphqlSettledWithUpdateCallCount(4);
+						await harness.expectGraphqlSettledWithEventCount(4);
 
 						expect(harness.subscriptionLogs()).toEqual([
 							['original title', 1],
@@ -453,7 +453,7 @@ describe('DataStore sync engine', () => {
 						await postHarness.revise('post title 2');
 
 						await harness.fullSettle();
-						await harness.expectGraphqlSettledWithUpdateCallCount(3);
+						await harness.expectGraphqlSettledWithEventCount(3);
 
 						expect(
 							harness.subscriptionLogs(['title', 'blogId', '_version'])
@@ -498,7 +498,7 @@ describe('DataStore sync engine', () => {
 						await postHarness.revise('post title 2');
 
 						await harness.fullSettle();
-						await harness.expectGraphqlSettledWithUpdateCallCount(4);
+						await harness.expectGraphqlSettledWithEventCount(4);
 
 						expect(
 							harness.subscriptionLogs(['title', 'blogId', '_version'])
@@ -538,7 +538,7 @@ describe('DataStore sync engine', () => {
 						await postHarness.revise('post title 2');
 
 						await harness.fullSettle();
-						await harness.expectGraphqlSettledWithUpdateCallCount(4);
+						await harness.expectGraphqlSettledWithEventCount(4);
 
 						expect(
 							harness.subscriptionLogs(['title', 'blogId', '_version'])
@@ -584,7 +584,7 @@ describe('DataStore sync engine', () => {
 						await postHarness.revise('post title 2');
 
 						await harness.fullSettle();
-						await harness.expectGraphqlSettledWithUpdateCallCount(4);
+						await harness.expectGraphqlSettledWithEventCount(4);
 
 						expect(
 							harness.subscriptionLogs(['title', 'blogId', '_version' ?? null])
@@ -622,7 +622,7 @@ describe('DataStore sync engine', () => {
 
 						await postHarness.revise('post title 2');
 
-						await harness.expectGraphqlSettledWithUpdateCallCount(4);
+						await harness.expectGraphqlSettledWithEventCount(4);
 
 						expect(
 							harness.subscriptionLogs(['title', 'blogId', '_version'])
@@ -666,7 +666,696 @@ describe('DataStore sync engine', () => {
 
 						await postHarness.revise('post title 2');
 
-						await harness.expectGraphqlSettledWithUpdateCallCount(4);
+						await harness.expectGraphqlSettledWithEventCount(4);
+
+						expect(
+							harness.subscriptionLogs(['title', 'blogId', '_version'])
+						).toEqual([
+							['original title', null, 1],
+							['post title 0', null, 1],
+							['post title 0', null, 2],
+							['post title 1', null, 2],
+							['post title 1', null, 3],
+							['post title 1', 'update from second client', 4],
+							['post title 2', 'update from second client', 4],
+							['post title 2', 'update from second client', 5],
+						]);
+
+						expect(await postHarness.currentContents).toMatchObject({
+							_version: 5,
+							title: 'post title 2',
+							blogId: 'update from second client',
+						});
+					});
+				});
+			});
+		});
+	});
+
+	describe('OptimisticConcurrency conflict resolution', () => {
+		beforeEach(async () => {
+			harness = new UpdateSequenceHarness('OptimisticConcurrency');
+			await harness.startDatastore();
+		});
+
+		afterEach(async () => {
+			await harness.destroy();
+		});
+
+		describe('observed rapid single-field mutations with variable connection latencies', () => {
+			describe('single client updates', () => {
+				test('no input delay, high latency where we wait for the create to clear the outbox', async () => {
+					const postHarness = await harness.createPostHarness({
+						title: 'original title',
+						blogId: 'blog id',
+					});
+
+					harness.latency = 'high';
+
+					await postHarness.revise('post title 0');
+					await postHarness.revise('post title 1');
+					await postHarness.revise('post title 2');
+
+					await harness.fullSettle();
+					await harness.expectGraphqlSettledWithEventCount({
+						update: 3,
+						updateSubscriptionMessage: 2,
+						updateError: 1,
+					});
+
+					expect(harness.subscriptionLogs()).toEqual([
+						['original title', 1],
+						['post title 0', 1],
+						['post title 1', 1],
+						['post title 2', 1],
+						['post title 2', 3],
+						['post title 2', 3],
+					]);
+
+					expect(await postHarness.currentContents).toMatchObject({
+						_version: 3,
+						title: 'post title 2',
+					});
+				});
+				test('delayed input, low latency where we wait for the create to clear the outbox', async () => {
+					const postHarness = await harness.createPostHarness({
+						title: 'original title',
+						blogId: 'blog id',
+					});
+
+					harness.userInputDelayed();
+					harness.latency = 'low';
+
+					await postHarness.revise('post title 0');
+					await postHarness.revise('post title 1');
+					await postHarness.revise('post title 2');
+
+					await harness.fullSettle();
+					await harness.expectGraphqlSettledWithEventCount({
+						update: 4,
+						updateSubscriptionMessage: 3,
+						updateError: 1,
+					});
+
+					expect(harness.subscriptionLogs()).toEqual([
+						['original title', 1],
+						['post title 0', 1],
+						['post title 1', 1],
+						['post title 2', 1],
+						['post title 2', 4],
+					]);
+
+					expect(await postHarness.currentContents).toMatchObject({
+						_version: 4,
+						title: 'post title 2',
+					});
+				});
+				test("no input delay, high latency where we don't wait for the create to clear the outbox", async () => {
+					const postHarness = await harness.createPostHarness(
+						{
+							title: 'original title',
+							blogId: 'blog id',
+						},
+						false
+					);
+
+					harness.latency = 'high';
+
+					await postHarness.revise('post title 0');
+					await postHarness.revise('post title 1');
+					await postHarness.revise('post title 2');
+
+					await harness.fullSettle();
+					await harness.expectGraphqlSettledWithEventCount(0);
+
+					expect(harness.subscriptionLogs()).toEqual([
+						['post title 0', undefined],
+						['post title 1', undefined],
+						['post title 2', undefined],
+						['post title 2', 1],
+						['post title 2', 1],
+					]);
+
+					expect(await postHarness.currentContents).toMatchObject({
+						_version: 1,
+						title: 'post title 2',
+					});
+				});
+				test("delayed input, low latency where we don't wait for the create to clear the outbox", async () => {
+					const postHarness = await harness.createPostHarness(
+						{
+							title: 'original title',
+							blogId: 'blog id',
+						},
+						false
+					);
+
+					harness.userInputDelayed();
+					harness.latency = 'low';
+
+					// Note: We do NOT wait for the outbox to be empty here, because
+					// we want to test concurrent updates being processed by the outbox.
+					await postHarness.revise('post title 0');
+					await postHarness.revise('post title 1');
+					await postHarness.revise('post title 2');
+
+					await harness.fullSettle();
+					await harness.expectGraphqlSettledWithEventCount(0);
+
+					expect(harness.subscriptionLogs()).toEqual([
+						['post title 0', undefined],
+						['post title 1', undefined],
+						['post title 2', undefined],
+						['post title 2', 1],
+					]);
+
+					expect(await postHarness.currentContents).toMatchObject({
+						_version: 1,
+						title: 'post title 2',
+					});
+				});
+				test('no input delay, high latency where we wait for the create and all revisions to clear the outbox', async () => {
+					const postHarness = await harness.createPostHarness({
+						title: 'original title',
+						blogId: 'blog id',
+					});
+
+					harness.latency = 'high';
+					harness.settleAfterRevisions();
+
+					/**
+					 * We wait for the empty outbox on each mutation, because
+					 * we want to test non-concurrent updates (i.e. we want to make
+					 * sure all the updates are going out and are being observed)
+					 */
+
+					await postHarness.revise('post title 0');
+					await postHarness.revise('post title 1');
+					await postHarness.revise('post title 2');
+
+					await harness.expectGraphqlSettledWithEventCount(3);
+
+					expect(harness.subscriptionLogs()).toEqual([
+						['original title', 1],
+						['post title 0', 1],
+						['post title 0', 2],
+						['post title 0', 2],
+						['post title 1', 2],
+						['post title 1', 3],
+						['post title 1', 3],
+						['post title 2', 3],
+						['post title 2', 4],
+						['post title 2', 4],
+					]);
+
+					expect(await postHarness.currentContents).toMatchObject({
+						_version: 4,
+						title: 'post title 2',
+					});
+				});
+				test('no input delay, low latency where we wait for the create and all revisions to clear the outbox', async () => {
+					const postHarness = await harness.createPostHarness({
+						title: 'original title',
+						blogId: 'blog id',
+					});
+
+					harness.latency = 'low';
+					harness.settleAfterRevisions();
+
+					await postHarness.revise('post title 0');
+					await postHarness.revise('post title 1');
+					await postHarness.revise('post title 2');
+
+					await harness.expectGraphqlSettledWithEventCount(3);
+
+					expect(harness.subscriptionLogs()).toEqual([
+						['original title', 1],
+						['post title 0', 1],
+						['post title 0', 2],
+						['post title 1', 2],
+						['post title 1', 3],
+						['post title 2', 3],
+						['post title 2', 4],
+					]);
+
+					expect(await postHarness.currentContents).toMatchObject({
+						_version: 4,
+						title: 'post title 2',
+					});
+				});
+			});
+			/**
+			 * The following multi-client tests are almost identical to the single-client tests above:
+			 * as a result, the comments in these tests relate specifically to multi-client operations only.
+			 * The primary differences are that we inject external client updates, and add many permutations
+			 * on essentially the same patterns. For a complete understanding of how these tests work (why /
+			 * when we await the outbox, pause, wait for the service to settle, etc), refer to the
+			 * single-field tests.
+			 */
+			describe('Multi-client updates', () => {
+				describe('Updates to the same field', () => {
+					test('no input delay, high latency where we wait for the create to clear the outbox', async () => {
+						const postHarness = await harness.createPostHarness({
+							title: 'original title',
+							blogId: 'blog id',
+						});
+
+						harness.latency = 'high';
+
+						await postHarness.revise('post title 0');
+						await postHarness.revise('post title 1');
+						await harness.externalPostUpdate({
+							originalPostId: postHarness.original.id,
+							updatedFields: { title: 'update from second client' },
+							version: 1,
+						});
+						await postHarness.revise('post title 2');
+
+						await harness.fullSettle();
+						await harness.expectGraphqlSettledWithEventCount({
+							update: 4,
+							updateSubscriptionMessage: 3,
+							updateError: 1,
+						});
+						expect(harness.subscriptionLogs()).toEqual([
+							['original title', 1],
+							['post title 0', 1],
+							['post title 1', 1],
+							['post title 2', 1],
+							['post title 2', 4],
+							['post title 2', 4],
+						]);
+
+						expect(await postHarness.currentContents).toMatchObject({
+							_version: 4,
+							title: 'post title 2',
+						});
+					});
+					test('delayed input, low latency where we wait for the create to clear the outbox', async () => {
+						const postHarness = await harness.createPostHarness({
+							title: 'original title',
+							blogId: 'blog id',
+						});
+
+						harness.userInputDelayed();
+						harness.latency = 'low';
+
+						await postHarness.revise('post title 0');
+						await postHarness.revise('post title 1');
+						try {
+							await harness.externalPostUpdate({
+								originalPostId: postHarness.original.id,
+								updatedFields: { title: 'update from second client' },
+								version: 1,
+							});
+						} catch (e) {
+							expect(e).toEqual(occRejectionError);
+						}
+						await postHarness.revise('post title 2');
+
+						await harness.fullSettle();
+						await harness.expectGraphqlSettledWithEventCount({
+							update: 5,
+							updateSubscriptionMessage: 3,
+							updateError: 2,
+						});
+
+						expect(harness.subscriptionLogs()).toEqual([
+							['original title', 1],
+							['post title 0', 1],
+							['post title 1', 1],
+							['post title 2', 1],
+							['post title 2', 4],
+						]);
+
+						expect(await postHarness.currentContents).toMatchObject({
+							_version: 4,
+							title: 'post title 2',
+						});
+					});
+					test('no input delay, high latency where we wait for the create and all revisions to clear the outbox', async () => {
+						const postHarness = await harness.createPostHarness({
+							title: 'original title',
+							blogId: 'blog id',
+						});
+
+						harness.latency = 'high';
+						harness.settleAfterRevisions();
+
+						await postHarness.revise('post title 0');
+						await postHarness.revise('post title 1');
+
+						await harness.externalPostUpdate({
+							originalPostId: postHarness.original.id,
+							updatedFields: { title: 'update from second client' },
+							version: 3,
+						});
+
+						await postHarness.revise('post title 2');
+
+						await harness.expectGraphqlSettledWithEventCount(4);
+
+						expect(harness.subscriptionLogs()).toEqual([
+							['original title', 1],
+							['post title 0', 1],
+							['post title 0', 2],
+							['post title 0', 2],
+							['post title 1', 2],
+							['post title 1', 3],
+							// Note: The subscription event for post title 1
+							// is processed after the second client update
+							// and the updated content is observed (below)
+							['update from second client', 4],
+							['update from second client', 4],
+							['post title 2', 4],
+							['post title 2', 5],
+							['post title 2', 5],
+						]);
+
+						expect(await postHarness.currentContents).toMatchObject({
+							_version: 5,
+							title: 'post title 2',
+						});
+					});
+
+					test('no input delay, low latency where we wait for the create and all revisions to clear the outbox', async () => {
+						const postHarness = await harness.createPostHarness({
+							title: 'original title',
+							blogId: 'blog id',
+						});
+
+						harness.latency = 'low';
+						harness.settleAfterRevisions();
+
+						await postHarness.revise('post title 0');
+						await postHarness.revise('post title 1');
+
+						await harness.externalPostUpdate({
+							originalPostId: postHarness.original.id,
+							updatedFields: { title: 'update from second client' },
+							version: 3,
+						});
+
+						await postHarness.revise('post title 2');
+
+						await harness.expectGraphqlSettledWithEventCount(4);
+
+						expect(harness.subscriptionLogs()).toEqual([
+							['original title', 1],
+							['post title 0', 1],
+							['post title 0', 2],
+							['post title 1', 2],
+							['post title 1', 3],
+							['update from second client', 4],
+							['post title 2', 4],
+							['post title 2', 5],
+						]);
+
+						expect(await postHarness.currentContents).toMatchObject({
+							_version: 5,
+							title: 'post title 2',
+						});
+					});
+				});
+				describe('Updates to different fields', () => {
+					/**
+					 * NOTE: Even though the primary client is updating `title`,
+					 * the second client's update to `blogId` "reverts" the primary
+					 * client's changes. This is because the external update takes
+					 * effect while the primary client's updates are still in flight.
+					 * By the time the primary client's update reaches the service,
+					 * the `_version` has changed. As a result, auto-merge chooses
+					 * the existing server-side `title` over the proposed updated
+					 * `title`. The following two tests demonstrate this behavior,
+					 * with a difference in the timing of the external request,
+					 * ultimately resulting in different final states.
+					 */
+					test('no input delay, high latency where we wait for the create to clear the outbox', async () => {
+						const postHarness = await harness.createPostHarness({
+							title: 'original title',
+						});
+
+						harness.latency = 'high';
+
+						await postHarness.revise('post title 0');
+						await postHarness.revise('post title 1');
+
+						await harness.externalPostUpdate({
+							originalPostId: postHarness.original.id,
+							// External client performs a mutation against a different field:
+							updatedFields: { blogId: 'update from second client' },
+							version: 1,
+						});
+
+						await postHarness.revise('post title 2');
+
+						await harness.fullSettle();
+						await harness.expectGraphqlSettledWithEventCount({
+							update: 4,
+							updateSubscriptionMessage: 3,
+							updateError: 1,
+						});
+
+						expect(
+							harness.subscriptionLogs(['title', 'blogId', '_version'])
+						).toEqual([
+							['original title', null, 1],
+							['post title 0', null, 1],
+							['post title 1', null, 1],
+							['post title 2', null, 1],
+							// The 'post title 2' change fails and is retried
+							// The retry fills in null for the blogId, which
+							// overwrites the externally set value
+							['post title 2', null, 4],
+							['post title 2', null, 4],
+						]);
+
+						expect(await postHarness.currentContents).toMatchObject({
+							_version: 4,
+							title: 'post title 2',
+						});
+					});
+					test('no input delay, high latency where we wait for the create to clear the outbox', async () => {
+						const postHarness = await harness.createPostHarness({
+							title: 'original title',
+						});
+
+						harness.latency = 'high';
+
+						await postHarness.revise('post title 0');
+						await postHarness.revise('post title 1');
+
+						/**
+						 * Ensure that the external update is received after the
+						 * primary client's first update.
+						 */
+						await pause(3000);
+
+						try {
+							await harness.externalPostUpdate({
+								originalPostId: postHarness.original.id,
+								// External client performs a mutation against a different field:
+								updatedFields: { blogId: 'update from second client' },
+								version: 1,
+							});
+						} catch (e) {
+							expect(e).toEqual(occRejectionError);
+						}
+
+						await postHarness.revise('post title 2');
+
+						await harness.fullSettle();
+						await harness.expectGraphqlSettledWithEventCount({
+							update: 4,
+							updateSubscriptionMessage: 3,
+							updateError: 1,
+						});
+
+						expect(
+							harness.subscriptionLogs(['title', 'blogId', '_version'])
+						).toEqual([
+							['original title', null, 1],
+							['post title 0', null, 1],
+							['post title 1', null, 1],
+							['post title 2', null, 1],
+							// The 'post title 2' change fails and is retried
+							// The retry fills in null for the blogId, which
+							// overwrites the externally set value
+							['post title 2', null, 4],
+							['post title 2', null, 4],
+						]);
+
+						expect(await postHarness.currentContents).toMatchObject({
+							_version: 4,
+							title: 'post title 2',
+						});
+					});
+					test('delayed input, low latency where we wait for the create to clear the outbox (second field is `null`)', async () => {
+						const postHarness = await harness.createPostHarness({
+							title: 'original title',
+						});
+
+						harness.userInputDelayed();
+						harness.latency = 'low';
+
+						await postHarness.revise('post title 0');
+						await postHarness.revise('post title 1');
+
+						await harness.externalPostUpdate({
+							originalPostId: postHarness.original.id,
+							// External client performs a mutation against a different field:
+							updatedFields: { blogId: 'update from second client' },
+							version: 2,
+						});
+
+						await postHarness.revise('post title 2');
+
+						await harness.fullSettle();
+						await harness.expectGraphqlSettledWithEventCount({
+							update: 5,
+							updateSubscriptionMessage: 4,
+							updateError: 1,
+						});
+
+						expect(
+							harness.subscriptionLogs(['title', 'blogId', '_version'])
+						).toEqual([
+							['original title', null, 1],
+							['post title 0', null, 1],
+							['post title 1', null, 1],
+							['post title 2', null, 1],
+							// The 'post title 2' change fails and is retried
+							// The retry fills in null for the blogId, which
+							// overwrites the externally set value
+							['post title 2', null, 5],
+						]);
+
+						expect(await postHarness.currentContents).toMatchObject({
+							_version: 5,
+							title: 'post title 2',
+						});
+					});
+					/**
+					 * All other multi-client tests begin with a `null` value to the field that is being
+					 * updated by the external client (`blogId`).
+					 * This is the only scenario where providing an inital value to `blogId` will result
+					 * in different behavior.
+					 */
+					test('delayed input, low latency where we wait for the create to clear the outbox (second field has initial value)', async () => {
+						const postHarness = await harness.createPostHarness({
+							title: 'original title',
+							blogId: 'original blogId',
+						});
+
+						harness.userInputDelayed();
+						harness.latency = 'low';
+
+						await postHarness.revise('post title 0');
+						await postHarness.revise('post title 1');
+
+						try {
+							await harness.externalPostUpdate({
+								originalPostId: postHarness.original.id,
+								// External client performs a mutation against a different field:
+								updatedFields: { blogId: 'update from second client' },
+								version: 1,
+							});
+						} catch (e) {
+							expect(e).toEqual(occRejectionError);
+						}
+
+						await postHarness.revise('post title 2');
+
+						await harness.fullSettle();
+						await harness.expectGraphqlSettledWithEventCount({
+							update: 5,
+							updateSubscriptionMessage: 3,
+							updateError: 2,
+						});
+
+						expect(
+							harness.subscriptionLogs(['title', 'blogId', '_version' ?? null])
+						).toEqual([
+							['original title', 'original blogId', 1],
+							['post title 0', 'original blogId', 1],
+							['post title 1', 'original blogId', 1],
+							['post title 2', 'original blogId', 1],
+							// The 'post title 2' change fails and is retried
+							// The retry fills in null for the blogId, which
+							// overwrites the externally set value
+							['post title 2', null, 4],
+						]);
+
+						expect(await postHarness.currentContents).toMatchObject({
+							_version: 4,
+							title: 'post title 2',
+						});
+					});
+					test('no input delay, high latency where we wait for the create and all revisions to clear the outbox', async () => {
+						const postHarness = await harness.createPostHarness({
+							title: 'original title',
+						});
+
+						harness.latency = 'high';
+						harness.settleAfterRevisions();
+
+						await postHarness.revise('post title 0');
+						await postHarness.revise('post title 1');
+
+						await harness.externalPostUpdate({
+							originalPostId: postHarness.original.id,
+							// External client performs a mutation against a different field:
+							updatedFields: { blogId: 'update from second client' },
+							version: 3,
+						});
+
+						await postHarness.revise('post title 2');
+
+						await harness.expectGraphqlSettledWithEventCount(4);
+
+						expect(
+							harness.subscriptionLogs(['title', 'blogId', '_version'])
+						).toEqual([
+							['original title', null, 1],
+							['post title 0', null, 1],
+							['post title 0', null, 2],
+							['post title 0', null, 2],
+							['post title 1', null, 2],
+							['post title 1', null, 3],
+							['post title 1', 'update from second client', 4],
+							['post title 1', 'update from second client', 4],
+							['post title 2', 'update from second client', 4],
+							['post title 2', 'update from second client', 5],
+							['post title 2', 'update from second client', 5],
+						]);
+
+						expect(await postHarness.currentContents).toMatchObject({
+							_version: 5,
+							title: 'post title 2',
+							blogId: 'update from second client',
+						});
+					});
+					test('no input delay, low latency where we wait for the create and all revisions to clear the outbox', async () => {
+						const postHarness = await harness.createPostHarness({
+							title: 'original title',
+						});
+
+						harness.latency = 'low';
+						harness.settleAfterRevisions();
+
+						await postHarness.revise('post title 0');
+						await postHarness.revise('post title 1');
+
+						await harness.externalPostUpdate({
+							originalPostId: postHarness.original.id,
+							// External client performs a mutation against a different field:
+							updatedFields: { blogId: 'update from second client' },
+							version: 3,
+						});
+
+						await postHarness.revise('post title 2');
+
+						await harness.expectGraphqlSettledWithEventCount(4);
 
 						expect(
 							harness.subscriptionLogs(['title', 'blogId', '_version'])

--- a/packages/datastore/__tests__/conflictResolutionBehavior.test.ts
+++ b/packages/datastore/__tests__/conflictResolutionBehavior.test.ts
@@ -102,6 +102,7 @@ describe('DataStore sync engine', () => {
 						blogId: 'blog id',
 					});
 
+					harness.userInputDelayed();
 					harness.latency = 'low';
 
 					await postHarness.revise('post title 0');
@@ -367,6 +368,7 @@ describe('DataStore sync engine', () => {
 							// Note: The subscription event for post title 1
 							// is processed after the second client update
 							// and the updated content is observed (below)
+							['update from second client', 4],
 							['update from second client', 4],
 							['update from second client', 4],
 							['post title 2', 4],

--- a/packages/datastore/__tests__/conflictResolutionBehavior.test.ts
+++ b/packages/datastore/__tests__/conflictResolutionBehavior.test.ts
@@ -102,7 +102,6 @@ describe('DataStore sync engine', () => {
 						blogId: 'blog id',
 					});
 
-					harness.userInputDelayed();
 					harness.latency = 'low';
 
 					await postHarness.revise('post title 0');

--- a/packages/datastore/__tests__/conflictResolutionBehavior.test.ts
+++ b/packages/datastore/__tests__/conflictResolutionBehavior.test.ts
@@ -1371,7 +1371,6 @@ describe('DataStore sync engine', () => {
 					['post title 2', 'update from second client', 4],
 					['post title 2', 'update from second client', 5],
 				]);
-
 				expect(await postHarness.currentContents).toMatchObject({
 					_version: 5,
 					title: 'post title 2',

--- a/packages/datastore/__tests__/helpers/UpdateSequenceHarness.ts
+++ b/packages/datastore/__tests__/helpers/UpdateSequenceHarness.ts
@@ -220,6 +220,7 @@ export class UpdateSequenceHarness {
 	 */
 	async outboxSettled() {
 		await waitForEmptyOutbox();
+		await Promise.all(subscriptionDeliveryPromiseList);
 	}
 
 	/**
@@ -267,7 +268,7 @@ export class UpdateSequenceHarness {
 		const original = await this.datastoreFake.DataStore.save(
 			new this.datastoreFake.Post(args)
 		);
-        // We set this to `false` when we want to test updating a record that is still in the outbox.
+		// We set this to `false` when we want to test updating a record that is still in the outbox.
 		if (settleOutbox) {
 			await this.outboxSettled();
 		}

--- a/packages/datastore/__tests__/helpers/UpdateSequenceHarness.ts
+++ b/packages/datastore/__tests__/helpers/UpdateSequenceHarness.ts
@@ -267,7 +267,7 @@ export class UpdateSequenceHarness {
 		const original = await this.datastoreFake.DataStore.save(
 			new this.datastoreFake.Post(args)
 		);
-		// We set this to `false` when we want to test updating a record that is still in the outbox.
+        // We set this to `false` when we want to test updating a record that is still in the outbox.
 		if (settleOutbox) {
 			await this.outboxSettled();
 		}

--- a/packages/datastore/__tests__/helpers/UpdateSequenceHarness.ts
+++ b/packages/datastore/__tests__/helpers/UpdateSequenceHarness.ts
@@ -204,8 +204,6 @@ export class UpdateSequenceHarness {
 			isNode: false,
 		});
 
-		this.latency = 'low';
-
 		this.subscriptionLogSubscription = this.datastoreFake.DataStore.observe(
 			this.datastoreFake.Post
 		).subscribe(({ opType, element }) => {

--- a/packages/datastore/__tests__/helpers/UpdateSequenceHarness.ts
+++ b/packages/datastore/__tests__/helpers/UpdateSequenceHarness.ts
@@ -220,6 +220,20 @@ export class UpdateSequenceHarness {
 	 */
 	async outboxSettled() {
 		await waitForEmptyOutbox();
+	}
+
+	/**
+	 * Wait for all subscription events to be delivered
+	 */
+	async subscriptionDeliverySettled() {
+		await Promise.all(subscriptionDeliveryPromiseList);
+	}
+
+	/**
+	 * Wait for the outbox and all subscription events to settle
+	 */
+	async fullSettle() {
+		await waitForEmptyOutbox();
 		await Promise.all(subscriptionDeliveryPromiseList);
 	}
 

--- a/packages/datastore/__tests__/helpers/UpdateSequenceHarness.ts
+++ b/packages/datastore/__tests__/helpers/UpdateSequenceHarness.ts
@@ -204,6 +204,8 @@ export class UpdateSequenceHarness {
 			isNode: false,
 		});
 
+		this.latency = 'low';
+
 		this.subscriptionLogSubscription = this.datastoreFake.DataStore.observe(
 			this.datastoreFake.Post
 		).subscribe(({ opType, element }) => {

--- a/packages/datastore/__tests__/helpers/datastoreFactory.ts
+++ b/packages/datastore/__tests__/helpers/datastoreFactory.ts
@@ -47,6 +47,7 @@ import {
 	ModelWithMultipleCustomOwner,
 	ModelWithIndexes,
 } from './schemas';
+import { MergeStrategy } from './fakes/graphqlService';
 
 type initSchemaType = typeof _initSchema;
 type DataStoreType = typeof DataStoreInstance;
@@ -62,16 +63,18 @@ export function getDataStore({
 	online = false,
 	isNode = true,
 	storageAdapterFactory = () => undefined as any,
+	mergeStrategy = 'Automerge',
 }: {
 	online?: boolean;
 	isNode?: boolean;
 	storageAdapterFactory?: () => any;
+	mergeStrategy?: MergeStrategy;
 } = {}) {
 	jest.clearAllMocks();
 	jest.resetModules();
 
 	const connectivityMonitor = new FakeDataStoreConnectivity();
-	const graphqlService = new FakeGraphQLService(testSchema());
+	const graphqlService = new FakeGraphQLService(testSchema(), mergeStrategy);
 
 	/**
 	 * Simulates the (re)connection of all returned fakes/mocks that

--- a/packages/datastore/__tests__/helpers/fakes/graphqlService.ts
+++ b/packages/datastore/__tests__/helpers/fakes/graphqlService.ts
@@ -39,6 +39,13 @@ const defaultLatencies: FakeLatencies = {
 	jitter: 5,
 };
 
+/**
+ * Keep a list of all subscription delivery promises where each promise
+ * resolves after the related message is delivered to all subscribers.
+ *
+ * This helps us track that all messages are delivered before proceeding
+ * with tests. The lists should be cleared between tests.
+ */
 export let subscriptionDeliveryPromiseList: Promise<void>[] = [];
 
 /**

--- a/packages/datastore/__tests__/helpers/fakes/graphqlService.ts
+++ b/packages/datastore/__tests__/helpers/fakes/graphqlService.ts
@@ -40,6 +40,22 @@ const defaultLatencies: FakeLatencies = {
 };
 
 /**
+ * Keep a list of all subscription delivery promises where each promise
+ * resolves after the related message is delivered to all subscribers.
+ *
+ * This helps us track that all messages are delivered before proceeding
+ * with tests. The lists should be cleared between tests.
+ */
+export let subscriptionDeliveryPromiseList: Promise<void>[] = [];
+
+/**
+ * Clear the subscription delivery promise list
+ */
+export function clearSubscriptionDeliveryPromiseList() {
+	subscriptionDeliveryPromiseList = [];
+}
+
+/**
  * Statefully pretends to be AppSync, with minimal built-in assertions with
  * error callbacks and settings to help simulate various conditions.
  */
@@ -495,29 +511,33 @@ export class FakeGraphQLService {
 		selection,
 		ignoreLatency = false
 	) {
-		!ignoreLatency && (await this.jitteredPause(this.latencies.subscriber));
-		const observers = this.getObservers(tableName, type);
-		const typeName = {
-			create: 'Create',
-			update: 'Update',
-			delete: 'Delete',
-		}[type];
-		const observerMessageName = `on${typeName}${tableName}`;
-		observers.forEach(observer => {
-			const message = {
-				data: {
-					[observerMessageName]: data[selection],
-				},
-			};
-			if (!this.stopSubscriptionMessages) {
-				this.log('API subscription message', {
-					observerMessageName,
-					message,
-				});
-				this.subscriptionMessagesSent.push([observerMessageName, message]);
-				observer.next(message);
-			}
+		const deliveryPromise = new Promise<void>(async resolve => {
+			!ignoreLatency && (await this.jitteredPause(this.latencies.subscriber));
+			const observers = this.getObservers(tableName, type);
+			const typeName = {
+				create: 'Create',
+				update: 'Update',
+				delete: 'Delete',
+			}[type];
+			const observerMessageName = `on${typeName}${tableName}`;
+			observers.forEach(observer => {
+				const message = {
+					data: {
+						[observerMessageName]: data[selection],
+					},
+				};
+				if (!this.stopSubscriptionMessages) {
+					this.log('API subscription message', {
+						observerMessageName,
+						message,
+					});
+					this.subscriptionMessagesSent.push([observerMessageName, message]);
+					observer.next(message);
+				}
+			});
+			resolve();
 		});
+		subscriptionDeliveryPromiseList.push(deliveryPromise);
 	}
 
 	public graphql(request: GraphQLRequest, ignoreLatency: boolean = false) {

--- a/packages/datastore/__tests__/helpers/fakes/graphqlService.ts
+++ b/packages/datastore/__tests__/helpers/fakes/graphqlService.ts
@@ -39,6 +39,15 @@ const defaultLatencies: FakeLatencies = {
 	jitter: 5,
 };
 
+export let subscriptionDeliveryPromiseList: Promise<void>[] = [];
+
+/**
+ * Clear the subscription delivery promise list
+ */
+export function clearSubscriptionDeliveryPromiseList() {
+	subscriptionDeliveryPromiseList = [];
+}
+
 /**
  * Keep a list of all subscription delivery promises where each promise
  * resolves after the related message is delivered to all subscribers.

--- a/packages/datastore/__tests__/helpers/util.ts
+++ b/packages/datastore/__tests__/helpers/util.ts
@@ -459,7 +459,9 @@ export async function waitForSyncQueriesReady(verbose = false) {
  */
 type GraphQLServiceSettledParams = {
 	graphqlService: any;
-	expectedCallCount: number;
+	expectedUpdateCallCount: number;
+	expectedUpdateSubscriptionMessageCount: number;
+	expectedUpdateErrorCount: number;
 	modelName: string;
 };
 
@@ -470,9 +472,11 @@ type GraphQLServiceSettledParams = {
  *
  * @param inputs: Tells us the service fake, expected call count and model to observe
  */
-export async function waitForExpectModelUpdateGraphqlCallCount({
+export async function waitForExpectModelUpdateGraphqlEventCount({
 	graphqlService,
-	expectedCallCount,
+	expectedUpdateCallCount,
+	expectedUpdateSubscriptionMessageCount,
+	expectedUpdateErrorCount,
 	modelName,
 }: GraphQLServiceSettledParams) {
 	/**
@@ -483,7 +487,11 @@ export async function waitForExpectModelUpdateGraphqlCallCount({
 	await pause(1);
 
 	// Keep track of the observed count for each retry so we can tell the developer what was observed last
-	let lastObservedCount: number | undefined = undefined;
+	let lastObservedUpdateCount: number | undefined = undefined;
+	let lastObservedSubscriptionCount: number | undefined = undefined;
+	let lastObservedUpdateErrorCount: number | undefined = undefined;
+
+	expectedUpdateSubscriptionMessageCount ??= expectedUpdateCallCount;
 
 	/**
 	 * Due to the addition of artificial latencies, the service may not be
@@ -496,7 +504,7 @@ export async function waitForExpectModelUpdateGraphqlCallCount({
 				const subscriptionMessagesNotStopped =
 					!graphqlService.stopSubscriptionMessages;
 
-				lastObservedCount = graphqlService.requests.filter(
+				lastObservedUpdateCount = graphqlService.requests.filter(
 					({ operation, type, tableName }) =>
 						operation === 'mutation' &&
 						type === 'update' &&
@@ -504,24 +512,38 @@ export async function waitForExpectModelUpdateGraphqlCallCount({
 				).length;
 
 				// Ensure the service has received all expected requests:
-				const allUpdatesSent = lastObservedCount === expectedCallCount;
+				const allUpdatesSent =
+					lastObservedUpdateCount === expectedUpdateCallCount;
 
 				// Ensure all mutations are complete:
 				const allRunningMutationsComplete =
 					graphqlService.runningMutations.size === 0;
 
 				// Ensure we've notified subscribers:
-				const allSubscriptionsSent =
+				lastObservedSubscriptionCount =
 					graphqlService.subscriptionMessagesSent.filter(
 						([observerMessageName, message]) => {
 							return observerMessageName === `onUpdate${modelName}`;
 						}
-					).length === expectedCallCount;
+					).length;
+				const allSubscriptionsSent =
+					lastObservedSubscriptionCount ===
+					expectedUpdateSubscriptionMessageCount;
+
+				lastObservedUpdateErrorCount =
+					graphqlService.errors
+						.get('update')
+						?.filter(([observerMessageName, _message]) => {
+							return observerMessageName === `update${modelName}`;
+						})?.length ?? 0;
+				const allErrorsReceived =
+					lastObservedUpdateErrorCount === expectedUpdateErrorCount;
 
 				if (
 					allUpdatesSent &&
 					allRunningMutationsComplete &&
 					allSubscriptionsSent &&
+					allErrorsReceived &&
 					subscriptionMessagesNotStopped
 				) {
 					return true;
@@ -539,9 +561,27 @@ export async function waitForExpectModelUpdateGraphqlCallCount({
 	} catch {
 		// If the expected call count isn't observed after 5 seconds, raise an error describing the discrepency
 		throw new Error(
-			`Expected ${expectedCallCount} update calls for ${modelName}, but received ${
-				lastObservedCount ?? 'unknown'
+			`Expected ${expectedUpdateCallCount} update calls for ${modelName}, but received ${
+				lastObservedUpdateCount ?? 'unknown'
+			}. Expected ${expectedUpdateSubscriptionMessageCount} subscription messages for ${modelName}, but received ${
+				lastObservedSubscriptionCount ?? 'unknown'
+			}. Expected ${expectedUpdateErrorCount} update errors for ${modelName}, but received ${
+				lastObservedUpdateErrorCount ?? 'unknown'
 			}`
 		);
 	}
 }
+
+/**
+ * A matcher that matches the error raised when OCC merge doesn't have matched versions
+ */
+export const occRejectionError = expect.objectContaining({
+	data: {
+		updatePost: null,
+	},
+	errors: [
+		expect.objectContaining({
+			message: 'Conflict resolver rejects mutation.',
+		}),
+	],
+});


### PR DESCRIPTION
> [!WARNING]
> PR reconstructed against main - Please see https://github.com/aws-amplify/amplify-js/pull/12795


#### Description of changes
Outcomes:
- Update graphql service fake to mimic OptimisticConcurrency(OCC) conflict resolution
- Add OptimisticConcurrency (OCC) tests for all cases covered by the existing Automerge tests

This change adds an outer block in the tests, which change whitespace for the entire file. I strongly recommend reviewing without whitespace changes.
<img width="196" alt="image" src="https://github.com/stocaaro/amplify-js/assets/94858815/499e1bb1-d266-4a7d-80c3-460885fe23f3">


#### Description of how you validated changes
By comparing sample app results to test expectations and iterating until they align.

There is existing odd behavior where errors occur at in low latency conditions where the retry message includes null values for fields, which overwrites external updates. I will do sample app testing to confirm that this is consistent with the real world behavior.

#### Related changes

1. https://github.com/aws-amplify/amplify-js/pull/12728
2. https://github.com/aws-amplify/amplify-js/pull/12732
3. https://github.com/aws-amplify/amplify-js/pull/12740
4. :seedling:  **test(datastore): Add OptimisticConcurrency tests**
5. https://github.com/stocaaro/amplify-js/pull/87

#### Checklist

- [x] PR description included
- [x] `yarn test` passes
- [x] Tests are [changed or added](https://github.com/aws-amplify/amplify-js/blob/main/CONTRIBUTING.md#steps-towards-contributions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
